### PR TITLE
Fix contradictory AIMS coaching tips

### DIFF
--- a/app/prompts/aims_fallback_feedback.txt
+++ b/app/prompts/aims_fallback_feedback.txt
@@ -7,6 +7,7 @@ Avoid stock phrases and avoid score references.
 Rules:
 - Preserve the detected step and the score exactly as provided.
 - Use one primary reason and one actionable tip by default.
+- Tips must target a missing or weak behavior. Do not suggest a behavior the clinician already performed in the current turn; if they asked an open concern question, coach the actual gap instead, such as pausing, avoiding stacked questions, or keeping the question neutral.
 - If the turn is compound, provide one `step_feedback` entry for each component step.
 - Each `step_feedback` item must be either praise or a concrete improvement suggestion.
 - Do not invent follow-up logistics that were not stated.

--- a/app/prompts/aims_system_instruction.txt
+++ b/app/prompts/aims_system_instruction.txt
@@ -8,6 +8,7 @@ You are an expert clinical communication evaluator specializing in the AIMS fram
 4. **Per-step feedback**: For compound steps (e.g. Mirror+Inquire), provide a separate `step_feedback` entry for EACH component. Do not collapse feedback into a single statement that only evaluates one component.
 5. **Concrete behavioral coaching**: Instead of scalar framing ("decent mirror"), describe the specific behavior: "You reflected the safety concern clearly. Before moving into reassurance, try checking whether you captured it accurately."
 6. **Grounding**: Do not overstate what the clinician explicitly offered. For example, say "offered to revisit the decision" when the clinician says "we can revisit it"; only say "scheduled/booked a follow-up" when an appointment, timing, or booking was actually proposed.
+7. **Tips must target a missing or weak behavior**: Do not put praise in `tips`, and do not suggest a behavior the clinician already performed in the current turn. If they asked an open concern question, do not tell them to lead with an open question; coach the actual gap instead, such as pausing, avoiding stacked questions, or keeping the question neutral.
 
 # AIMS FRAMEWORK REFERENCE
 
@@ -187,7 +188,7 @@ Return JSON with the following structure. For compound steps, `step_feedback` MU
     "steps": ["Step1", "Step2"],
     "score": 0-3,
     "reasons": ["second-person phrase-citing feedback"],
-    "tips": ["max 1, specific and actionable"],
+    "tips": ["max 1, specific and actionable improvement for a behavior not already done"],
     "step_feedback": [
       {"step": "Mirror", "feedback": "You reflected her safety concern clearly using 'You're worried that…'", "tone": "praise"},
       {"step": "Inquire", "feedback": "The follow-up question was somewhat generic — try targeting a specific concern area", "tone": "improvement"}

--- a/app/services/aims_coaching_handler.py
+++ b/app/services/aims_coaching_handler.py
@@ -41,6 +41,7 @@ from app.services.chat_context import ChatContext
 from app.services.chat_helpers import strip_appointment_headers
 from app.services.classifier_service import ClassifierService
 from app.services.clinician_identity import clinician_display_name_from_user_info
+from app.services.coaching_tip_sanitizer import sanitize_coaching_tips
 from app.services.aims_dependencies import (
     AimsEndgameDependency,
     AimsFeedbackDependency,
@@ -361,6 +362,8 @@ class AimsCoachingHandler:
                 )
             except Exception as e:
                 self.logger.debug("AIMS feedback refinement failed: %s", e)
+
+        sanitize_coaching_tips(cls_payload, clinician_message=body.message)
 
         # Step 4: Persist AIMS metrics (after state update)
         try:

--- a/app/services/aims_state_service.py
+++ b/app/services/aims_state_service.py
@@ -18,6 +18,7 @@ from app.constants import (
     STEP_SECURE_INQUIRE,
 )
 from app.services.aims_metrics_service import AimsMetricsService
+from app.services.coaching_tip_sanitizer import opens_with_open_concern_question
 from app.services.conversation_service import (
     mark_mirrored_multi,
     mark_secured_by_topic,
@@ -323,8 +324,12 @@ class AimsStateService:
     ) -> None:
         first_inquire_done = state.get("first_inquire_done", False)
         if not first_inquire_done:
-            reason = "You moved into reassurance before asking about their concerns — try an open question first"
-            tip = "Ask what's on their mind (e.g., 'What are your thoughts about the vaccines we discussed?') before offering reassurance."
+            if opens_with_open_concern_question(clinician_message):
+                reason = "You asked an open question, then moved into reassurance before giving them space to answer."
+                tip = "After asking what's on their mind, pause before offering reassurance."
+            else:
+                reason = "You moved into reassurance before asking about their concerns — try an open question first"
+                tip = "Ask what's on their mind (e.g., 'What are your thoughts about the vaccines we discussed?') before offering reassurance."
             cls_payload["reasons"] = [reason] + (cls_payload.get("reasons") or [])
             cls_payload.setdefault("tips", []).append(tip)
             try:

--- a/app/services/chainlit/orchestrator.py
+++ b/app/services/chainlit/orchestrator.py
@@ -440,9 +440,21 @@ class ChainlitOrchestrator:
             parts = []
             if coaching.get("step"):
                 parts.append(f"Detected step: {coaching['step']}")
-            if coaching.get("reasons"):
+            step_feedback = coaching.get("step_feedback") or []
+            if step_feedback:
+                for sf in step_feedback:
+                    if not isinstance(sf, dict):
+                        continue
+                    feedback = (sf.get("feedback") or "").strip()
+                    if not feedback:
+                        continue
+                    label = "Great job" if sf.get("tone") == "praise" else "Try"
+                    sf_step = (sf.get("step") or "").strip()
+                    prefix = f"{sf_step}: " if sf_step else ""
+                    parts.append(f"{prefix}{label}: {feedback}")
+            elif coaching.get("reasons"):
                 parts.append(f"Feedback: {coaching['reasons'][0]}")
-            if coaching.get("tips"):
+            if coaching.get("tips") and not step_feedback:
                 parts.append(f"Tip: {coaching['tips'][0]}")
 
             if parts:

--- a/app/services/coaching_tip_sanitizer.py
+++ b/app/services/coaching_tip_sanitizer.py
@@ -62,8 +62,9 @@ def sanitize_coaching_tips(
         cls_payload.get("step"),
         cls_payload.get("steps"),
     )
+    raw_score = cls_payload.get("score")
     try:
-        score = int(cls_payload.get("score"))
+        score = None if raw_score is None else int(raw_score)
     except (TypeError, ValueError):
         score = None
 

--- a/app/services/coaching_tip_sanitizer.py
+++ b/app/services/coaching_tip_sanitizer.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.constants import STEP_INQUIRE
+from app.services.aims_metrics_service import AimsMetricsService
+
+
+_OPEN_QUESTION_TIP_RE = re.compile(
+    r"\b(?:try\s+)?(?:lead|leading|start|starting|begin|beginning)\s+with\s+(?:an?\s+)?open[- ]?(?:ended[- ]?)?question\b"
+    r"|\b(?:try\s+)?(?:ask|use)\s+(?:an?\s+)?open[- ]?(?:ended[- ]?)?question\b"
+    r"|\bprefer\s+(?:what\s+and\s+how|what/how)\s+questions\b"
+    r"|\b(?:ask|try asking)\s+what'?s on (?:their|your) mind\b"
+    r"|\b(?:ask|try asking)\s+what is on (?:their|your) mind\b",
+    re.IGNORECASE,
+)
+
+_OPEN_CONCERN_QUESTION_RE = re.compile(
+    r"\b("
+    r"what|how|tell me|help me understand|could you share|can you share|would you share"
+    r")\b[^?.!]*(?:"
+    r"thought|concern|worr|heard|feel|mind|question|hesitan|matter|understand"
+    r")",
+    re.IGNORECASE,
+)
+
+_LEADING_QUESTION_RE = re.compile(
+    r"\b(don't you|wouldn't you|isn't it|right\?|myth|misinformation)\b",
+    re.IGNORECASE,
+)
+
+
+def has_open_concern_question(text: str | None) -> bool:
+    """Return True when the current turn asks an open concern-surfacing question."""
+    return bool(_OPEN_CONCERN_QUESTION_RE.search(text or ""))
+
+
+def opens_with_open_concern_question(text: str | None) -> bool:
+    """Return True when the first move is an open concern-surfacing question."""
+    stripped = (text or "").strip()
+    if not stripped:
+        return False
+    first_sentence = re.split(r"[.!?]\s+", stripped, maxsplit=1)[0]
+    return bool(_OPEN_CONCERN_QUESTION_RE.match(first_sentence))
+
+
+def is_open_question_tip(tip: str | None) -> bool:
+    """Return True when a tip asks for an open question or what/how phrasing."""
+    return bool(_OPEN_QUESTION_TIP_RE.search(tip or ""))
+
+
+def sanitize_coaching_tips(
+    cls_payload: dict[str, Any],
+    *,
+    clinician_message: str | None,
+) -> dict[str, Any]:
+    """Drop or replace feedback that criticizes a behavior already present this turn."""
+    tips = cls_payload.get("tips") or []
+
+    components = AimsMetricsService.component_steps(
+        cls_payload.get("step"),
+        cls_payload.get("steps"),
+    )
+    try:
+        score = int(cls_payload.get("score"))
+    except (TypeError, ValueError):
+        score = None
+
+    message_has_open_question = has_open_concern_question(clinician_message)
+    detected_solid_inquire = STEP_INQUIRE in components and (score is None or score >= 2)
+    already_opened = message_has_open_question or detected_solid_inquire
+
+    sanitized: list[str] = []
+    for raw_tip in tips:
+        tip = str(raw_tip or "").strip()
+        if not tip:
+            continue
+        if already_opened and is_open_question_tip(tip):
+            replacement = _replacement_for_open_question_tip(clinician_message)
+            if replacement and replacement not in sanitized:
+                sanitized.append(replacement)
+            continue
+        if tip not in sanitized:
+            sanitized.append(tip)
+
+    cls_payload["tips"] = sanitized[:1]
+    cls_payload["step_feedback"] = _sanitize_step_feedback(
+        cls_payload.get("step_feedback") or [],
+        already_opened=already_opened,
+        clinician_message=clinician_message,
+        replacement_tips=cls_payload["tips"],
+    )
+    return cls_payload
+
+
+def _sanitize_step_feedback(
+    raw_step_feedback: list[Any],
+    *,
+    already_opened: bool,
+    clinician_message: str | None,
+    replacement_tips: list[str],
+) -> list[dict[str, str]]:
+    sanitized: list[dict[str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for raw_item in raw_step_feedback:
+        item = _step_feedback_dict(raw_item)
+        if not item:
+            continue
+
+        feedback = str(item.get("feedback") or "").strip()
+        if not feedback:
+            continue
+
+        if already_opened and is_open_question_tip(feedback):
+            replacement = (
+                _replacement_for_open_question_tip(clinician_message)
+                or _first_non_open_question_tip(replacement_tips)
+            )
+            if not replacement:
+                continue
+            feedback = replacement
+            item["feedback"] = replacement
+            item["tone"] = "improvement"
+
+        item["step"] = str(item.get("step") or "").strip()
+        item["feedback"] = feedback
+        item["tone"] = str(item.get("tone") or "improvement").strip().lower()
+        if item["tone"] not in {"praise", "improvement"}:
+            item["tone"] = "improvement"
+
+        key = (item["step"], item["feedback"], item["tone"])
+        if key in seen:
+            continue
+        seen.add(key)
+        sanitized.append(item)
+
+    return sanitized
+
+
+def _step_feedback_dict(raw_item: Any) -> dict[str, str] | None:
+    if isinstance(raw_item, dict):
+        return dict(raw_item)
+    if hasattr(raw_item, "model_dump"):
+        dumped = raw_item.model_dump()
+        return dict(dumped) if isinstance(dumped, dict) else None
+    return None
+
+
+def _first_non_open_question_tip(tips: list[str]) -> str | None:
+    for tip in tips:
+        if tip and not is_open_question_tip(tip):
+            return tip
+    return None
+
+
+def _replacement_for_open_question_tip(clinician_message: str | None) -> str | None:
+    text = clinician_message or ""
+    if text.count("?") > 1:
+        return "Ask one neutral question at a time, then pause so they have room to answer."
+    if _LEADING_QUESTION_RE.search(text):
+        return "Keep the question neutral so it does not signal the answer you prefer."
+    if re.search(r"(^|\s)why\s", text, re.IGNORECASE):
+        return "Use what or how phrasing instead of why, which can feel accusatory."
+    return None

--- a/docs/aims/classification-scoring-rules.md
+++ b/docs/aims/classification-scoring-rules.md
@@ -438,6 +438,10 @@ a fallback.  It requires both `FOLLOWUP_CUES` and `LITERATURE_CUES` to match, or
 ## 10. Scoring Tip Policy
 
 - At most **one tip** per turn (enforced by `classify_turn`).
+- Tips must target a missing or weak behavior in the current turn. If the clinician already
+  asked an open concern question, the coach should not say to lead with an open question; it
+  should coach the actual gap instead, such as pausing, avoiding stacked questions, or keeping
+  the question neutral.
 - Tips are suppressed when all known concerns have already been mirrored (tip would be stale
   advice to mirror a concern that was already addressed).
 - "Secure before mirror" tips escalate on repetition: first occurrence = standard nudge; second

--- a/tests/regression/test_announce_inquire.py
+++ b/tests/regression/test_announce_inquire.py
@@ -186,6 +186,37 @@ class TestSecuringBeforeInquiringCoaching:
         assert cls_payload["score"] <= 2
         assert any("open question" in t.lower() or "thoughts" in t.lower() for t in cls_payload["tips"])
 
+    def test_secure_open_question_then_reassurance_gets_pause_feedback(self):
+        """If the turn already opened with inquiry, feedback should not say to ask first."""
+        state = {
+            "announced": True,
+            "phase": "PreAnnounce",
+            "first_inquire_done": False,
+            "parent_concerns": [],
+            "recent_coaching": [],
+        }
+        cls_payload = {
+            "step": "Secure",
+            "score": 3,
+            "reasons": ["LLM classified as Secure"],
+            "tips": [],
+        }
+
+        AimsStateService(logger=MagicMock()).apply_coaching_guidance(
+            cls_payload,
+            "Secure",
+            state,
+            "What concerns do you have about the MMR vaccine? It is safe and effective.",
+            "",
+            character=None,
+        )
+
+        feedback = " ".join(cls_payload["reasons"] + cls_payload["tips"]).lower()
+        assert "you asked an open question" in feedback
+        assert "before asking" not in feedback
+        assert "open question first" not in feedback
+        assert "pause before offering reassurance" in feedback
+
     def test_secure_after_inquire_no_coaching_about_inquiring(self):
         """When first_inquire_done is True and concerns are mirrored,
         should NOT get 'Securing before inquiring' warning."""

--- a/tests/unit/prompts/test_prompt_and_override_improvements.py
+++ b/tests/unit/prompts/test_prompt_and_override_improvements.py
@@ -69,6 +69,13 @@ class TestPromptContent:
         assert "praise" in instruction.lower()
         assert "improvement" in instruction.lower()
 
+    def test_system_instruction_prevents_tips_for_behavior_already_done(self):
+        """Tips should target actual gaps, not already-successful behavior."""
+        instruction = get_classify_system_instruction().lower()
+        assert "do not suggest a behavior the clinician already performed" in instruction
+        assert "if they asked an open concern question" in instruction
+        assert "pausing" in instruction
+
     def test_person_topic_excludes_literature_followup_acceptance(self):
         """Prompts must not turn literature/follow-up agreement into autonomy concerns."""
         active = self._active_classifier_prompt(
@@ -143,6 +150,7 @@ class TestPromptContent:
         assert "avoid stock phrases" in lower
         assert "preserve the detected step and the score" in lower
         assert "step_feedback" in lower
+        assert "do not suggest a behavior the clinician already performed" in lower
 
     def test_classify_turn_prompt_renders_context_and_concern_lists(self):
         prompt = build_classify_turn_prompt(

--- a/tests/unit/services/chainlit/test_chainlit_orchestrator.py
+++ b/tests/unit/services/chainlit/test_chainlit_orchestrator.py
@@ -488,6 +488,44 @@ async def test_process_backend_response_dispatches_coaching_reply_and_coach_post
 
 
 @pytest.mark.asyncio
+async def test_process_backend_response_prefers_step_feedback_over_raw_tip(
+    orchestrator, mock_services
+):
+    mock_services["session"].history = []
+    mock_services["session"].persona_name = "Sarah"
+    mock_services["ui"].send_coach_message = AsyncMock()
+    mock_services["ui"].send_assistant_reply = AsyncMock()
+
+    await orchestrator._process_backend_response(
+        {
+            "coaching": {
+                "step": "Secure",
+                "reasons": ["You asked and then reassured."],
+                "tips": ["Try leading with an open question."],
+                "step_feedback": [
+                    {
+                        "step": "Inquire",
+                        "tone": "praise",
+                        "feedback": "You opened with a broad concern question.",
+                    },
+                    {
+                        "step": "Secure",
+                        "tone": "improvement",
+                        "feedback": "Pause before moving into reassurance.",
+                    },
+                ],
+            },
+            "reply": "I need to understand more.",
+        }
+    )
+
+    coach_text = mock_services["session"].history[0]["content"]
+    assert "Inquire: Great job: You opened with a broad concern question." in coach_text
+    assert "Secure: Try: Pause before moving into reassurance." in coach_text
+    assert "Tip: Try leading with an open question." not in coach_text
+
+
+@pytest.mark.asyncio
 async def test_process_backend_response_handles_empty_coaching_and_default_coach_post_title(
     orchestrator, mock_services
 ):

--- a/tests/unit/services/test_aims_coaching_handler_injection.py
+++ b/tests/unit/services/test_aims_coaching_handler_injection.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from app.constants import KEY_COACH_POST, KEY_GAME_OVER, SESSION_HISTORY
+from app.constants import KEY_AIMS_STATE, KEY_COACH_POST, KEY_GAME_OVER, SESSION_HISTORY
 from app.models import ChatRequest, ClassifierResult, Coaching
 from app.services.aims_coaching_handler import AimsCoachingHandler
 from app.services.aims_turn_coordinator import AimsTurnResult
@@ -111,6 +111,7 @@ def _turn(
     score=2,
     reasons=None,
     tips=None,
+    step_feedback=None,
     is_small_talk=False,
     patient_reply="Thanks, Doctor.",
     was_fallback=False,
@@ -122,8 +123,9 @@ def _turn(
             step=step,
             steps=[step] if step else [],
             score=score,
-            reasons=reasons or ["Clear recommendation."],
-            tips=tips or ["Ask what questions they have."],
+            reasons=["Clear recommendation."] if reasons is None else reasons,
+            tips=["Ask what questions they have."] if tips is None else tips,
+            step_feedback=step_feedback or [],
         ),
         safety_flags=[],
         person_topic=None,
@@ -290,6 +292,74 @@ async def test_handle_refines_fallback_coaching_when_available(monkeypatch):
     handler.feedback_service.refine_fallback_feedback.assert_awaited_once()
     assert result["coaching"]["tips"] == ["Name that it is her decision before offering the fact."]
     assert result["coaching"]["step_feedback"][0]["feedback"] == "You gave reassurance before naming her choice."
+
+
+@pytest.mark.asyncio
+async def test_handle_sanitizes_stale_step_feedback_after_state_guidance(monkeypatch):
+    feedback = _feedback()
+    endgame = _endgame()
+    turn_coordinator = Mock()
+    turn_coordinator.run = AsyncMock(
+        return_value=_turn(
+            step="Secure",
+            score=3,
+            reasons=["LLM classified as Secure."],
+            tips=[],
+            step_feedback=[
+                {
+                    "step": "Secure",
+                    "tone": "improvement",
+                    "feedback": "Try leading with an open question before reassurance.",
+                }
+            ],
+        )
+    )
+
+    handler = _handler(
+        classifier=Mock(),
+        patient_reply=Mock(),
+        metrics=_metrics(),
+        feedback=feedback,
+        endgame=endgame,
+        turn_coordinator=turn_coordinator,
+    )
+
+    async def fake_mapping():
+        return {}
+
+    monkeypatch.setattr(handler, "_load_aims_mapping", fake_mapping)
+
+    ctx = _basic_context()
+    ctx.mem[KEY_AIMS_STATE] = {
+        "phase": "PreAnnounce",
+        "announced": True,
+        "first_inquire_done": False,
+        "parent_concerns": [],
+        "recent_coaching": [],
+    }
+
+    result = await handler.handle(
+        req=Mock(headers={}),
+        body=ChatRequest(
+            message="What concerns do you have about the MMR vaccine? It is safe and effective.",
+            sessionId="sid",
+            coach=True,
+        ),
+        ctx=ctx,
+    )
+
+    assert result["coaching"]["tips"] == [
+        "After asking what's on their mind, pause before offering reassurance."
+    ]
+    assert result["coaching"]["step_feedback"] == [
+        {
+            "step": "Secure",
+            "tone": "improvement",
+            "feedback": "After asking what's on their mind, pause before offering reassurance.",
+        }
+    ]
+    feedback_payload = feedback.append.call_args.kwargs["cls_payload"]
+    assert "Try leading with an open question" not in str(feedback_payload)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_coaching_tip_sanitizer.py
+++ b/tests/unit/services/test_coaching_tip_sanitizer.py
@@ -1,0 +1,130 @@
+from app.services.coaching_tip_sanitizer import (
+    has_open_concern_question,
+    opens_with_open_concern_question,
+    sanitize_coaching_tips,
+)
+
+
+def test_detects_open_concern_question():
+    text = "What are your thoughts about the MMR vaccine? I can answer anything."
+
+    assert has_open_concern_question(text) is True
+    assert opens_with_open_concern_question(text) is True
+
+
+def test_sanitize_drops_open_question_tip_when_turn_already_asked_one():
+    payload = {
+        "step": "Secure",
+        "score": 2,
+        "reasons": ["You asked and then reassured."],
+        "tips": ["Try leading with an open question."],
+    }
+
+    sanitize_coaching_tips(
+        payload,
+        clinician_message="What concerns do you have about MMR? It is very safe.",
+    )
+
+    assert payload["tips"] == []
+
+
+def test_sanitize_keeps_pause_tip_after_open_question():
+    payload = {
+        "step": "Secure",
+        "score": 2,
+        "tips": ["After asking what's on their mind, pause before offering reassurance."],
+    }
+
+    sanitize_coaching_tips(
+        payload,
+        clinician_message="What concerns do you have about MMR? It is very safe.",
+    )
+
+    assert payload["tips"] == [
+        "After asking what's on their mind, pause before offering reassurance."
+    ]
+
+
+def test_sanitize_replaces_stale_step_feedback_with_corrected_tip():
+    payload = {
+        "step": "Secure",
+        "score": 2,
+        "tips": ["After asking what's on their mind, pause before offering reassurance."],
+        "step_feedback": [
+            {
+                "step": "Secure",
+                "tone": "improvement",
+                "feedback": "Try leading with an open question before reassurance.",
+            }
+        ],
+    }
+
+    sanitize_coaching_tips(
+        payload,
+        clinician_message="What concerns do you have about MMR? It is very safe.",
+    )
+
+    assert payload["step_feedback"] == [
+        {
+            "step": "Secure",
+            "tone": "improvement",
+            "feedback": "After asking what's on their mind, pause before offering reassurance.",
+        }
+    ]
+
+
+def test_sanitize_drops_stale_step_feedback_without_replacement():
+    payload = {
+        "step": "Secure",
+        "score": 2,
+        "tips": [],
+        "step_feedback": [
+            {
+                "step": "Secure",
+                "tone": "improvement",
+                "feedback": "Try leading with an open question before reassurance.",
+            }
+        ],
+    }
+
+    sanitize_coaching_tips(
+        payload,
+        clinician_message="What concerns do you have about MMR? It is very safe.",
+    )
+
+    assert payload["step_feedback"] == []
+
+
+def test_sanitize_replaces_stacked_open_question_tip_with_specific_gap():
+    payload = {
+        "step": "Inquire",
+        "score": 2,
+        "tips": ["Prefer what and how questions; avoid why when it can feel accusatory."],
+    }
+
+    sanitize_coaching_tips(
+        payload,
+        clinician_message=(
+            "What concerns do you have about MMR? "
+            "How are you feeling about the schedule?"
+        ),
+    )
+
+    assert payload["tips"] == [
+        "Ask one neutral question at a time, then pause so they have room to answer."
+    ]
+
+
+def test_sanitize_keeps_open_question_tip_when_behavior_is_missing():
+    payload = {
+        "step": "Secure",
+        "score": 1,
+        "tips": ["Try leading with an open question."],
+    }
+
+    sanitize_coaching_tips(
+        payload,
+        clinician_message="The MMR vaccine is safe and effective.",
+    )
+
+    assert payload["tips"] == ["Try leading with an open question."]

--- a/tests/unit/services/test_coaching_tip_sanitizer.py
+++ b/tests/unit/services/test_coaching_tip_sanitizer.py
@@ -12,6 +12,11 @@ def test_detects_open_concern_question():
     assert opens_with_open_concern_question(text) is True
 
 
+def test_opening_question_detector_handles_blank_text():
+    assert has_open_concern_question(None) is False
+    assert opens_with_open_concern_question("   ") is False
+
+
 def test_sanitize_drops_open_question_tip_when_turn_already_asked_one():
     payload = {
         "step": "Secure",
@@ -28,6 +33,21 @@ def test_sanitize_drops_open_question_tip_when_turn_already_asked_one():
     assert payload["tips"] == []
 
 
+def test_sanitize_ignores_blank_tip_and_invalid_score():
+    payload = {
+        "step": "Secure",
+        "score": "not-a-number",
+        "tips": ["", "Keep the wording neutral."],
+    }
+
+    sanitize_coaching_tips(
+        payload,
+        clinician_message="The MMR vaccine is safe and effective.",
+    )
+
+    assert payload["tips"] == ["Keep the wording neutral."]
+
+
 def test_sanitize_keeps_pause_tip_after_open_question():
     payload = {
         "step": "Secure",
@@ -42,6 +62,40 @@ def test_sanitize_keeps_pause_tip_after_open_question():
 
     assert payload["tips"] == [
         "After asking what's on their mind, pause before offering reassurance."
+    ]
+
+
+def test_sanitize_replaces_open_question_tip_for_leading_question():
+    payload = {
+        "step": "Inquire",
+        "score": 2,
+        "tips": ["Try leading with an open question."],
+    }
+
+    sanitize_coaching_tips(
+        payload,
+        clinician_message="Don't you think the MMR concerns are manageable?",
+    )
+
+    assert payload["tips"] == [
+        "Keep the question neutral so it does not signal the answer you prefer."
+    ]
+
+
+def test_sanitize_replaces_open_question_tip_for_why_question():
+    payload = {
+        "step": "Inquire",
+        "score": 2,
+        "tips": ["Try leading with an open question."],
+    }
+
+    sanitize_coaching_tips(
+        payload,
+        clinician_message="Why are you worried about the MMR vaccine?",
+    )
+
+    assert payload["tips"] == [
+        "Use what or how phrasing instead of why, which can feel accusatory."
     ]
 
 
@@ -93,6 +147,73 @@ def test_sanitize_drops_stale_step_feedback_without_replacement():
     )
 
     assert payload["step_feedback"] == []
+
+
+def test_sanitize_keeps_stale_step_feedback_when_behavior_is_missing():
+    payload = {
+        "step": "Secure",
+        "score": 1,
+        "tips": [],
+        "step_feedback": [
+            {
+                "step": "Secure",
+                "tone": "improvement",
+                "feedback": "Try leading with an open question before reassurance.",
+            }
+        ],
+    }
+
+    sanitize_coaching_tips(
+        payload,
+        clinician_message="The MMR vaccine is safe and effective.",
+    )
+
+    assert payload["step_feedback"] == [
+        {
+            "step": "Secure",
+            "tone": "improvement",
+            "feedback": "Try leading with an open question before reassurance.",
+        }
+    ]
+
+
+def test_sanitize_normalizes_step_feedback_items():
+    class FeedbackObject:
+        def model_dump(self):
+            return {
+                "step": "Secure",
+                "tone": "unclear",
+                "feedback": "Keep the explanation brief.",
+            }
+
+    payload = {
+        "step": "Secure",
+        "score": 2,
+        "tips": [],
+        "step_feedback": [
+            "bad item",
+            {"step": "Secure", "tone": "praise", "feedback": ""},
+            FeedbackObject(),
+            {
+                "step": "Secure",
+                "tone": "unclear",
+                "feedback": "Keep the explanation brief.",
+            },
+        ],
+    }
+
+    sanitize_coaching_tips(
+        payload,
+        clinician_message="The MMR vaccine is safe and effective.",
+    )
+
+    assert payload["step_feedback"] == [
+        {
+            "step": "Secure",
+            "tone": "improvement",
+            "feedback": "Keep the explanation brief.",
+        }
+    ]
 
 
 def test_sanitize_replaces_stacked_open_question_tip_with_specific_gap():


### PR DESCRIPTION
## Summary

Fixes contradictory coaching feedback where AIMSBot could tell a learner to lead with an open question even when the current turn already opened with one.

## Root Cause

The Secure-before-Inquire guidance only looked at prior AIMS state, so a turn that asked an open concern question and then moved into reassurance could still receive the generic "ask first" nudge. Separately, live and replay coach rendering could prefer stale `step_feedback` over corrected top-level `reasons`/`tips`, allowing old contradictory feedback to remain visible.

## Changes

- Added a shared coaching tip sanitizer for contradictory open-question advice.
- Kept valid pause guidance such as "After asking what's on their mind, pause..." from being removed by the sanitizer.
- Sanitized `step_feedback` as well as top-level `tips` before API response assembly and history persistence.
- Updated Secure-before-Inquire guidance to distinguish missing inquiry from asking and then reassuring too quickly.
- Updated Chainlit live rendering to prefer structured per-step feedback and avoid displaying stale raw `Tip:` lines when step feedback is present.
- Tightened prompt and canonical AIMS documentation so tips target missing or weak behavior, not behavior already performed.

## Validation

- `.venv/bin/python -m pytest -q tests/unit/services/test_coaching_tip_sanitizer.py tests/unit/services/test_aims_coaching_handler_injection.py tests/regression/test_announce_inquire.py tests/unit/services/chainlit/test_chainlit_orchestrator.py`
  - `53 passed, 1 xfail`
- `.venv/bin/python -m pytest -q tests/unit/prompts/test_prompt_and_override_improvements.py tests/unit/services/test_coach_feedback_history_service.py`
  - `20 passed`
- `git diff --check`
- `.venv/bin/python -m compileall -q app chainlit_app.py scripts tests`