### PR TITLE
Ensure Cloud Run deploys route to latest revision

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -178,6 +178,12 @@ jobs:
             --cpu-throttling \
             --startup-probe="httpGet.path=/api/healthz,periodSeconds=10,timeoutSeconds=9,failureThreshold=12"
 
+      - name: Route traffic to latest revision
+        run: |
+          gcloud run services update-traffic "$SERVICE_NAME" \
+            --region "$REGION" \
+            --to-latest
+
       - name: Show service URL and health check
         run: |
           URL=$(gcloud run services describe "$SERVICE_NAME" --region "$REGION" --format 'value(status.url)')


### PR DESCRIPTION
## Summary
- Add an explicit Cloud Run `update-traffic --to-latest` step after deployment.
- Prevent staging/prod deploys from silently keeping traffic pinned to an older named revision.

## Verification
- Confirmed live staging was previously serving `aimsbot-staging-00087-zzx` at 100% traffic while newer revisions existed.
- Repaired live staging with `gcloud run services update-traffic aimsbot-staging --to-latest`; fresh Zia sessions now return the vaccine-protocol scenario.
- Ran `git diff --check`.
- Parsed workflow YAML with Python/PyYAML.
- Ran `actionlint .github/workflows/deploy.yaml`.