### PR TITLE
Vary praise labels in coaching feedback

### DIFF
--- a/app/prompts/aims_fallback_feedback.txt
+++ b/app/prompts/aims_fallback_feedback.txt
@@ -7,9 +7,9 @@ Avoid stock phrases and avoid score references.
 Rules:
 - Preserve the detected step and the score exactly as provided.
 - Use one primary reason and one actionable tip by default.
-- Tips must target a missing or weak behavior. Do not suggest a behavior the clinician already performed in the current turn; if they asked an open concern question, coach the actual gap instead, such as pausing, avoiding stacked questions, or keeping the question neutral.
+- Tips must target a missing or weak behavior. Write them as direct action phrases without a leading "Tip:" or "Try:" label. Do not suggest a behavior the clinician already performed in the current turn; if they asked an open concern question, coach the actual gap instead, such as pausing, avoiding stacked questions, or keeping the question neutral.
 - If the turn is compound, provide one `step_feedback` entry for each component step.
-- Each `step_feedback` item must be either praise or a concrete improvement suggestion.
+- Each `step_feedback` item must be either past-tense praise or a concrete improvement suggestion. Write `tone: "improvement"` feedback as a direct action phrase because the UI labels it with "Tip:".
 - Do not invent follow-up logistics that were not stated.
 - Do not overstate what the clinician did; stay grounded in the input.
 - If the turn is mostly rapport or small talk, keep the coaching gentle and brief.

--- a/app/prompts/aims_system_instruction.txt
+++ b/app/prompts/aims_system_instruction.txt
@@ -4,11 +4,11 @@ You are an expert clinical communication evaluator specializing in the AIMS fram
 
 1. **Voice**: Always use second-person ("You reflected…", "You moved into reassurance before…"). Never use third-person ("The clinician…").
 2. **No score references**: Never mention numeric scores in feedback, reasons, or tips. Do not say "To elevate this to a 3" or "This scores a 2". Describe the behavior that needs to change, not the number.
-3. **Tone**: Every feedback item must be unambiguously praise OR a specific improvement suggestion. Avoid ambiguous phrasing like "The introduction is soft and indirect" — instead say either "✓ You introduced vaccines gently" (praise) or "→ Try a more direct recommendation" (improvement).
+3. **Tone**: Every feedback item must be unambiguously praise OR a specific improvement suggestion. Praise feedback should be past-tense second-person feedback about what the clinician did well. Improvement feedback should be a direct action phrase, because the UI labels it with `Tip:`. Avoid ambiguous phrasing like "The introduction is soft and indirect" — instead say either "You introduced vaccines gently" (praise) or "Make a more direct recommendation" (improvement).
 4. **Per-step feedback**: For compound steps (e.g. Mirror+Inquire), provide a separate `step_feedback` entry for EACH component. Do not collapse feedback into a single statement that only evaluates one component.
-5. **Concrete behavioral coaching**: Instead of scalar framing ("decent mirror"), describe the specific behavior: "You reflected the safety concern clearly. Before moving into reassurance, try checking whether you captured it accurately."
+5. **Concrete behavioral coaching**: Instead of scalar framing ("decent mirror"), describe the specific behavior: "You reflected the safety concern clearly. Before moving into reassurance, check whether you captured it accurately."
 6. **Grounding**: Do not overstate what the clinician explicitly offered. For example, say "offered to revisit the decision" when the clinician says "we can revisit it"; only say "scheduled/booked a follow-up" when an appointment, timing, or booking was actually proposed.
-7. **Tips must target a missing or weak behavior**: Do not put praise in `tips`, and do not suggest a behavior the clinician already performed in the current turn. If they asked an open concern question, do not tell them to lead with an open question; coach the actual gap instead, such as pausing, avoiding stacked questions, or keeping the question neutral.
+7. **Tips must target a missing or weak behavior**: Do not put praise in `tips`, and do not suggest a behavior the clinician already performed in the current turn. Write tips as direct action phrases without a leading "Tip:" or "Try:" label, because the UI adds the label. If they asked an open concern question, do not tell them to lead with an open question; coach the actual gap instead, such as pausing, avoiding stacked questions, or keeping the question neutral.
 
 # AIMS FRAMEWORK REFERENCE
 
@@ -188,10 +188,10 @@ Return JSON with the following structure. For compound steps, `step_feedback` MU
     "steps": ["Step1", "Step2"],
     "score": 0-3,
     "reasons": ["second-person phrase-citing feedback"],
-    "tips": ["max 1, specific and actionable improvement for a behavior not already done"],
+    "tips": ["max 1, direct action phrase for a behavior not already done"],
     "step_feedback": [
       {"step": "Mirror", "feedback": "You reflected her safety concern clearly using 'You're worried that…'", "tone": "praise"},
-      {"step": "Inquire", "feedback": "The follow-up question was somewhat generic — try targeting a specific concern area", "tone": "improvement"}
+      {"step": "Inquire", "feedback": "Target a specific concern area with the follow-up question", "tone": "improvement"}
     ]
   },
   "safety_flags": [],

--- a/app/services/chainlit/orchestrator.py
+++ b/app/services/chainlit/orchestrator.py
@@ -27,6 +27,8 @@ from app.services.chainlit.ui_handler import UIHandler
 
 logger = logging.getLogger(__name__)
 
+_PRAISE_FEEDBACK_LABELS = ("Great job", "Well done", "Nice work", "Strong move")
+
 
 class ChainlitOrchestrator:
     """Orchestrates the high-level flow of the Chainlit application."""
@@ -442,16 +444,18 @@ class ChainlitOrchestrator:
                 parts.append(f"Detected step: {coaching['step']}")
             step_feedback = coaching.get("step_feedback") or []
             if step_feedback:
+                feedback_index = 0
                 for sf in step_feedback:
                     if not isinstance(sf, dict):
                         continue
                     feedback = (sf.get("feedback") or "").strip()
                     if not feedback:
                         continue
-                    label = "Great job" if sf.get("tone") == "praise" else "Try"
+                    label = self._step_feedback_label(sf.get("tone"), feedback_index)
                     sf_step = (sf.get("step") or "").strip()
                     prefix = f"{sf_step}: " if sf_step else ""
                     parts.append(f"{prefix}{label}: {feedback}")
+                    feedback_index += 1
             elif coaching.get("reasons"):
                 parts.append(f"Feedback: {coaching['reasons'][0]}")
             if coaching.get("tips") and not step_feedback:
@@ -478,6 +482,14 @@ class ChainlitOrchestrator:
             await self.ui.send_coach_message(combined)
 
         self.session.history = history
+
+    @staticmethod
+    def _step_feedback_label(tone: Any, feedback_index: int) -> str:
+        if tone == "praise":
+            return _PRAISE_FEEDBACK_LABELS[
+                feedback_index % len(_PRAISE_FEEDBACK_LABELS)
+            ]
+        return "Tip"
 
     async def _run_preflight_checks(self):
         if not await self.backend.check_health():

--- a/tests/unit/prompts/test_prompt_and_override_improvements.py
+++ b/tests/unit/prompts/test_prompt_and_override_improvements.py
@@ -65,9 +65,12 @@ class TestPromptContent:
     def test_system_instruction_has_feedback_tone_rules(self):
         """aims_system_instruction.txt must define praise/improvement tone rules."""
         instruction = get_classify_system_instruction()
-        assert "tone" in instruction.lower()
-        assert "praise" in instruction.lower()
-        assert "improvement" in instruction.lower()
+        lower = instruction.lower()
+        assert "tone" in lower
+        assert "praise" in lower
+        assert "improvement" in lower
+        assert "past-tense second-person" in lower
+        assert "ui labels it with `tip:`" in lower
 
     def test_system_instruction_prevents_tips_for_behavior_already_done(self):
         """Tips should target actual gaps, not already-successful behavior."""
@@ -151,6 +154,7 @@ class TestPromptContent:
         assert "preserve the detected step and the score" in lower
         assert "step_feedback" in lower
         assert "do not suggest a behavior the clinician already performed" in lower
+        assert 'ui labels it with "tip:"' in lower
 
     def test_classify_turn_prompt_renders_context_and_concern_lists(self):
         prompt = build_classify_turn_prompt(

--- a/tests/unit/services/chainlit/test_chainlit_orchestrator.py
+++ b/tests/unit/services/chainlit/test_chainlit_orchestrator.py
@@ -521,8 +521,54 @@ async def test_process_backend_response_prefers_step_feedback_over_raw_tip(
 
     coach_text = mock_services["session"].history[0]["content"]
     assert "Inquire: Great job: You opened with a broad concern question." in coach_text
-    assert "Secure: Try: Pause before moving into reassurance." in coach_text
+    assert "Secure: Tip: Pause before moving into reassurance." in coach_text
     assert "Tip: Try leading with an open question." not in coach_text
+
+
+@pytest.mark.asyncio
+async def test_process_backend_response_rotates_praise_step_feedback_labels(
+    orchestrator, mock_services
+):
+    mock_services["session"].history = []
+    mock_services["ui"].send_coach_message = AsyncMock()
+    mock_services["ui"].send_assistant_reply = AsyncMock()
+
+    await orchestrator._process_backend_response(
+        {
+            "coaching": {
+                "step": "Mirror+Secure+Inquire+Announce",
+                "step_feedback": [
+                    {
+                        "step": "Mirror",
+                        "tone": "praise",
+                        "feedback": "You reflected the parent's core worry.",
+                    },
+                    {
+                        "step": "Secure",
+                        "tone": "praise",
+                        "feedback": "You supported the parent's choice.",
+                    },
+                    {
+                        "step": "Inquire",
+                        "tone": "praise",
+                        "feedback": "You asked a collaborative open question.",
+                    },
+                    {
+                        "step": "Announce",
+                        "tone": "praise",
+                        "feedback": "You made a clear recommendation.",
+                    },
+                ],
+            },
+            "reply": "I appreciate that.",
+        }
+    )
+
+    coach_text = mock_services["session"].history[0]["content"]
+    assert "Mirror: Great job: You reflected the parent's core worry." in coach_text
+    assert "Secure: Well done: You supported the parent's choice." in coach_text
+    assert "Inquire: Nice work: You asked a collaborative open question." in coach_text
+    assert "Announce: Strong move: You made a clear recommendation." in coach_text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Rotate praise prefixes in Chainlit per-step coaching output: `Great job`, `Well done`, `Nice work`, `Strong move`.
- Keep non-praise per-step feedback under the more flexible `Tip:` label instead of `Try:`.
- Tighten classifier/refinement prompts so praise is past-tense second-person feedback and tips/improvements are direct action phrases without their own `Tip:` or `Try:` prefix.

## Verification
- `/Users/craigburnett/PycharmProjects/AIMSBot/.venv/bin/python -m pytest -q tests/unit/services/chainlit/test_chainlit_orchestrator.py tests/unit/prompts/test_prompt_and_override_improvements.py` (`47 passed, 1 xfailed`)
- `git diff --check`
- `/Users/craigburnett/PycharmProjects/AIMSBot/.venv/bin/python -m compileall -q app/services/chainlit/orchestrator.py tests/unit/services/chainlit/test_chainlit_orchestrator.py tests/unit/prompts/test_prompt_and_override_improvements.py`
- `/Users/craigburnett/PycharmProjects/AIMSBot/.venv/bin/ruff check app/services/chainlit/orchestrator.py tests/unit/services/chainlit/test_chainlit_orchestrator.py tests/unit/prompts/test_prompt_and_override_improvements.py`