### PR TITLE
Surface tips alongside praise-only step feedback

### DIFF
--- a/app/services/chainlit/orchestrator.py
+++ b/app/services/chainlit/orchestrator.py
@@ -443,6 +443,8 @@ class ChainlitOrchestrator:
             if coaching.get("step"):
                 parts.append(f"Detected step: {coaching['step']}")
             step_feedback = coaching.get("step_feedback") or []
+            displayed_step_feedback = 0
+            has_improvement_step_feedback = False
             if step_feedback:
                 feedback_index = 0
                 for sf in step_feedback:
@@ -451,14 +453,20 @@ class ChainlitOrchestrator:
                     feedback = (sf.get("feedback") or "").strip()
                     if not feedback:
                         continue
-                    label = self._step_feedback_label(sf.get("tone"), feedback_index)
+                    tone = sf.get("tone")
+                    label = self._step_feedback_label(tone, feedback_index)
                     sf_step = (sf.get("step") or "").strip()
                     prefix = f"{sf_step}: " if sf_step else ""
                     parts.append(f"{prefix}{label}: {feedback}")
+                    displayed_step_feedback += 1
+                    if tone != "praise":
+                        has_improvement_step_feedback = True
                     feedback_index += 1
             elif coaching.get("reasons"):
                 parts.append(f"Feedback: {coaching['reasons'][0]}")
-            if coaching.get("tips") and not step_feedback:
+            if coaching.get("tips") and (
+                not displayed_step_feedback or not has_improvement_step_feedback
+            ):
                 parts.append(f"Tip: {coaching['tips'][0]}")
 
             if parts:

--- a/app/services/coach_feedback_history_service.py
+++ b/app/services/coach_feedback_history_service.py
@@ -53,6 +53,8 @@ class CoachFeedbackHistoryService:
             if step and step not in ("null", "None"):
                 parts.append(f"Detected step: {step}")
 
+            displayed_step_feedback = 0
+            has_improvement_step_feedback = False
             if step_feedback:
                 for sf in step_feedback:
                     tone_icon = "\u2713" if sf.get("tone") == "praise" else "\u2192"
@@ -60,6 +62,9 @@ class CoachFeedbackHistoryService:
                     sf_text = sf.get("feedback", "")
                     if sf_text:
                         parts.append(f"{sf_step}: {tone_icon} {sf_text}")
+                        displayed_step_feedback += 1
+                        if sf.get("tone") != "praise":
+                            has_improvement_step_feedback = True
             else:
                 feedback = self.first_user_facing_reason(reasons, step=step)
                 if feedback:
@@ -71,7 +76,9 @@ class CoachFeedbackHistoryService:
                 t for t in tips
                 if not (already_announced and STEP_ANNOUNCE.lower() in (t or "").lower())
             ]
-            if tips_to_show and not step_feedback:
+            if tips_to_show and (
+                not displayed_step_feedback or not has_improvement_step_feedback
+            ):
                 parts.append(f"Tip: {tips_to_show[0]}")
 
             if reply_payload.get("resolution_type") == "deferred":

--- a/tests/unit/services/chainlit/test_chainlit_orchestrator.py
+++ b/tests/unit/services/chainlit/test_chainlit_orchestrator.py
@@ -526,6 +526,42 @@ async def test_process_backend_response_prefers_step_feedback_over_raw_tip(
 
 
 @pytest.mark.asyncio
+async def test_process_backend_response_shows_tip_with_praise_only_step_feedback(
+    orchestrator, mock_services
+):
+    mock_services["session"].history = []
+    mock_services["session"].persona_name = "Zia"
+    mock_services["ui"].send_coach_message = AsyncMock()
+    mock_services["ui"].send_assistant_reply = AsyncMock()
+
+    await orchestrator._process_backend_response(
+        {
+            "coaching": {
+                "step": "Secure",
+                "tips": [
+                    "Ask a single, open-ended question to check for understanding."
+                ],
+                "step_feedback": [
+                    {
+                        "step": "Secure",
+                        "tone": "praise",
+                        "feedback": "You led with a strong autonomy statement.",
+                    },
+                ],
+            },
+            "reply": "I would like to go slowly.",
+        }
+    )
+
+    coach_text = mock_services["session"].history[0]["content"]
+    assert "Secure: Great job: You led with a strong autonomy statement." in coach_text
+    assert (
+        "Tip: Ask a single, open-ended question to check for understanding."
+        in coach_text
+    )
+
+
+@pytest.mark.asyncio
 async def test_process_backend_response_rotates_praise_step_feedback_labels(
     orchestrator, mock_services
 ):

--- a/tests/unit/services/test_coach_feedback_history_service.py
+++ b/tests/unit/services/test_coach_feedback_history_service.py
@@ -101,6 +101,35 @@ def test_append_uses_step_feedback_and_deferred_nudge():
     assert "This should not show" not in text
 
 
+def test_append_shows_tip_when_step_feedback_is_praise_only():
+    service = _service()
+    mem = {}
+
+    service.append(
+        mem=mem,
+        memory_enabled=True,
+        session_id="sid",
+        cls_payload={
+            "step": "Secure",
+            "score": 2,
+            "phase": "Secure",
+            "step_feedback": [
+                {
+                    "step": "Secure",
+                    "tone": "praise",
+                    "feedback": "You affirmed autonomy clearly.",
+                },
+            ],
+            "tips": ["Ask one open-ended check-in question."],
+        },
+        reply_payload={},
+    )
+
+    text = mem[SESSION_HISTORY][0]["content"]
+    assert "Secure: \u2713 You affirmed autonomy clearly." in text
+    assert "Tip: Ask one open-ended check-in question." in text
+
+
 def test_filter_user_facing_reasons_and_first_reason():
     reasons = [
         "LLM flagged internal condition",


### PR DESCRIPTION
## Summary
- Surface top-level `Tip:` feedback when `step_feedback` is present but praise-only.
- Preserve the existing suppression behavior when `step_feedback` already includes an improvement item.
- Apply the same rule to Chainlit live formatting and persisted/replay coach history.

## Staging QA Evidence
I ran fresh synthetic staging sessions against `https://aimsbot-staging-chur7bpwsq-uc.a.run.app/` after #229 was merged and deployed.

The clearest repro was session `codex-bug-sweep-1785296747-e8ce667b`, Zia turn 3:
- Clinician stacked two check-in questions after a Secure move.
- Backend returned `score: 2` with a top-level tip: `Ask a single, open-ended question to check for understanding...`
- Backend `step_feedback` contained only praise.
- Current live/replay formatting suppresses top-level tips whenever any `step_feedback` exists, so the user sees only praise for an imperfect turn.

## Verification
- `/Users/craigburnett/PycharmProjects/AIMSBot/.venv/bin/python -m pytest -q tests/unit/services/chainlit/test_chainlit_orchestrator.py tests/unit/services/test_coach_feedback_history_service.py`
- `git diff --check`
- `/Users/craigburnett/PycharmProjects/AIMSBot/.venv/bin/python -m compileall -q app/services/chainlit/orchestrator.py app/services/coach_feedback_history_service.py tests/unit/services/chainlit/test_chainlit_orchestrator.py tests/unit/services/test_coach_feedback_history_service.py`
- `/Users/craigburnett/PycharmProjects/AIMSBot/.venv/bin/ruff check app/services/chainlit/orchestrator.py app/services/coach_feedback_history_service.py tests/unit/services/chainlit/test_chainlit_orchestrator.py tests/unit/services/test_coach_feedback_history_service.py`