### PR TITLE
Fix concern capture after polite preambles

### DIFF
--- a/app/services/aims_state_service.py
+++ b/app/services/aims_state_service.py
@@ -132,6 +132,19 @@ class AimsStateService:
         ],
     }
 
+    USER_FACING_TOPIC_HINTS = {
+        "autism": "autism concerns",
+        "immune_load": "immune load or spacing concerns",
+        "side_effects": "side-effect concerns",
+        "ingredients": "ingredient concerns",
+        "schedule_timing": "timing or schedule concerns",
+        "disease_risk": "whether the disease still feels like a real risk",
+        "effectiveness": "effectiveness or benefit concerns",
+        "trust": "trust or evidence concerns",
+        "autonomy": "choice or pressure concerns",
+        "requirements": "school or system requirements",
+    }
+
     ANALYTICAL_KEYWORDS = (
         "analytical",
         "data",
@@ -439,12 +452,12 @@ class AimsStateService:
                 reason = "You moved into education before reflecting the concern — try mirroring first so they feel heard"
                 tip = "Before educating, briefly reflect the concern (e.g., 'It feels like a lot at once — did I get that right?')."
         elif repeat_count == 1:
-            topic_hint = f" ('{first_unmirrored}')" if first_unmirrored else ""
+            topic_hint = self._user_facing_topic_hint(first_unmirrored)
             reason = f"You're still educating without reflecting — the concern{topic_hint} hasn't been mirrored yet"
-            tip = f"Try reflecting the specific concern{topic_hint} before more education."
+            tip = f"Reflect the specific concern{topic_hint} before more education."
         else:
             count = repeat_count + 1
-            topic_hint = f" about '{first_unmirrored}'" if first_unmirrored else ""
+            topic_hint = self._user_facing_topic_hint(first_unmirrored)
             reason = f"You've had {count} Secure turns without mirroring{topic_hint} — try pausing to reflect before more education"
             tip = f"Pause and mirror: acknowledge the concern{topic_hint} before sharing more facts."
 
@@ -501,6 +514,14 @@ class AimsStateService:
     def _secure_before_mirror_key(topic: str | None) -> str:
         normalized = str(topic).strip() if topic else ""
         return f"secure_before_mirror:{normalized}" if normalized else "secure_before_mirror"
+
+    @classmethod
+    def _user_facing_topic_hint(cls, topic: str | None) -> str:
+        normalized = str(topic or "").strip()
+        if not normalized:
+            return ""
+        label = cls.USER_FACING_TOPIC_HINTS.get(normalized, normalized.replace("_", " "))
+        return f" about {label}"
 
     @classmethod
     def _secure_before_mirror_repeat_count(cls, recent: list[Any], topic: str | None) -> int:

--- a/app/services/conversation_service.py
+++ b/app/services/conversation_service.py
@@ -161,6 +161,8 @@ def _clean_evidence_snippet(text: str) -> str:
 
     concern_starts = (
         "i want",
+        "i just want",
+        "i need",
         "i'm trying",
         "i am trying",
         "i'm still",
@@ -385,6 +387,26 @@ _HEDGING_CUES = (
     "what about", "what if",
 )
 
+_CONCERN_AFTER_ACCEPTANCE_CUES = (
+    "i want to understand",
+    "i just want to understand",
+    "i need to understand",
+    "i'm trying to understand",
+    "i am trying to understand",
+    "can you tell me",
+    "could you tell me",
+    "help me understand",
+    "is it required",
+    "is it mandatory",
+    "required for school",
+    "mandatory for school",
+    "need to explain",
+    "need to do",
+    "what vaccines",
+    "what shots",
+    "what happens",
+)
+
 _MATERIALS_OR_FOLLOWUP_CUES = (
     "take information home",
     "take some information home",
@@ -485,6 +507,12 @@ def _is_acceptance_message(text: str) -> bool:
         return False
     # Override: hedging language means there may be a real concern embedded
     if any(h in lt for h in _HEDGING_CUES):
+        return False
+    # Polite openers can introduce a substantive concern immediately after the
+    # acknowledgement, as in "Thank you. Can you tell me what is required?"
+    if any(cue in lt for cue in _CONCERN_AFTER_ACCEPTANCE_CUES):
+        return False
+    if "?" in lt and any(cue in lt for cue in ("what ", "how ", "why ", "is it ", "are they ", "do we ", "do i ")):
         return False
     return True
 

--- a/tests/regression/test_aims_improvements.py
+++ b/tests/regression/test_aims_improvements.py
@@ -257,7 +257,7 @@ def test_secure_before_mirror_first_time_gives_standard_feedback():
 
 
 def test_secure_before_mirror_second_time_escalates_with_topic():
-    """Second repetition should name the unmirrored concern topic."""
+    """Second repetition should name the unmirrored concern in user-facing language."""
     h = _state_service()
     state = _make_state(phase="InquireMirror", concerns=[
         {"desc": "x", "topic": "trust", "is_mirrored": False, "is_secured": False},
@@ -267,6 +267,35 @@ def test_secure_before_mirror_second_time_escalates_with_topic():
     h.apply_coaching_guidance(cls, "Secure", state, "Studies show...", "I don't trust pharma")
     assert "trust" in cls["reasons"][0].lower()
     assert "still" in cls["reasons"][0].lower() or "hasn't" in cls["reasons"][0].lower()
+    assert cls["tips"][0].startswith("Reflect the specific concern")
+    assert "try reflecting" not in cls["tips"][0].lower()
+
+
+def test_secure_before_mirror_repeated_tip_does_not_leak_internal_topic_keys():
+    """Repeated feedback should not expose taxonomy labels like disease_risk."""
+    h = _state_service()
+    state = _make_state(phase="InquireMirror", concerns=[
+        {"desc": "x", "topic": "disease_risk", "is_mirrored": False, "is_secured": False},
+    ])
+    state["recent_coaching"] = ["secure_before_mirror:disease_risk"]
+    cls = {"step": "Secure", "score": 2, "reasons": [], "tips": []}
+
+    h.apply_coaching_guidance(
+        cls,
+        "Secure",
+        state,
+        "Measles can spread quickly when vaccination rates drop.",
+        "I don't see measles around here.",
+    )
+
+    feedback = " ".join(cls["reasons"] + cls["tips"])
+    assert "disease_risk" not in feedback
+    assert "'disease" not in feedback
+    assert "whether the disease still feels like a real risk" in feedback
+    assert cls["tips"][0] == (
+        "Reflect the specific concern about whether the disease still feels like a real risk "
+        "before more education."
+    )
 
 
 def test_secure_before_mirror_third_time_escalates_to_pattern():

--- a/tests/unit/services/test_conversation_service.py
+++ b/tests/unit/services/test_conversation_service.py
@@ -131,6 +131,42 @@ def test_maybe_add_person_concern_skips_empty_acceptance_and_duplicates():
     assert len(st["parent_concerns"]) == 1
 
 
+def test_maybe_add_person_concern_keeps_question_after_polite_acceptance():
+    st = {"parent_concerns": []}
+
+    maybe_add_person_concern(
+        st,
+        (
+            "Thank you, Doctor. I want to understand what vaccines my son needs here. "
+            "Is it required for school?"
+        ),
+        AimsStateService.TOPICAL_CUES,
+    )
+
+    assert len(st["parent_concerns"]) == 1
+    concern = st["parent_concerns"][0]
+    assert concern["topic"] == "requirements"
+    assert concern["evidence"][0].startswith("I want to understand")
+
+
+def test_maybe_add_person_concern_keeps_need_to_understand_after_yes_preamble():
+    st = {"parent_concerns": []}
+
+    maybe_add_person_concern(
+        st,
+        (
+            "Yes, Doctor. That is right. I just want to understand clearly "
+            "so I can tell my husband Gabriel what we need to do for Nathaniel."
+        ),
+        AimsStateService.TOPICAL_CUES,
+    )
+
+    assert len(st["parent_concerns"]) == 1
+    concern = st["parent_concerns"][0]
+    assert concern["topic"] == "requirements"
+    assert concern["evidence"][0].startswith("I just want to understand")
+
+
 def test_maybe_add_person_concern_merges_same_topic_paraphrases_and_cleans_evidence():
     st = {"parent_concerns": []}
 


### PR DESCRIPTION
## Summary
- preserve substantive concern capture when a parent reply starts with a polite acknowledgement like "Thank you" or "Yes" and then asks a real vaccine/system question
- store cleaner concern evidence for "I just want..." and "I need..." preambles
- replace repeated Secure-before-Mirror internal topic hints such as `disease_risk` with user-facing language and remove the awkward `Try reflecting...` tip phrasing

## Root Cause
Live staging QA found a Zia protocol conversation that repeatedly accepted written information plus follow-up but did not reach endgame. The endgame gate was correctly requiring surfaced concern state before `accepted_literature` could close. The earlier concern-capture guard was too broad: `_is_acceptance_message()` skipped any reply starting with polite acceptance tokens, so Zia's "Thank you, Doctor. I want to understand... Is it required for school?" never became a `requirements` concern.

The same sweep found deterministic repeated Secure-before-Mirror tips that leaked internal taxonomy labels into user-facing coaching, for example `Tip: Try reflecting the specific concern ('disease_risk') before more education.`

## Validation
- `git diff --check`
- `python -m compileall -q app tests/unit/services/test_conversation_service.py tests/regression/test_aims_improvements.py`
- `python -m ruff check .`
- `python -m mypy app`
- `python -m pytest -q tests/unit/services/test_conversation_service.py tests/regression/test_aims_improvements.py`
- `python -m pytest -q tests/unit/services/test_conversation_service.py tests/regression/test_aims_improvements.py tests/unit/services/test_endgame_detection_unit.py tests/unit/services/test_coaching_tip_sanitizer.py tests/unit/services/test_coach_feedback_history_service.py tests/unit/services/chainlit/test_chainlit_orchestrator.py`

## Notes
The full non-live suite was also attempted with `python -m pytest --ignore=tests/integration -q`. It reached 91% total coverage but failed on unrelated local blockers: three frontend tests could not launch `node` in this worktree, and `tests/unit/services/chainlit/test_chainlit_callbacks.py::test_oauth_callback_google` expects `chainlit_app.oauth_callback`, which is not present on this branch.
