### PR TITLE
Fix Endgame never closing when clinician skips Mirror before Secure

### DIFF
--- a/app/services/aims_endgame_service.py
+++ b/app/services/aims_endgame_service.py
@@ -219,12 +219,13 @@ class AimsEndgameService:
                 structured_vaccine = self._structured_vaccine_resolution(result)
                 if structured_vaccine is False:
                     is_endgame = False
-
-                has_unsecured = any(not concern.get("is_secured") for concern in concerns)
-                # The detector reads the transcript; stale local concern state must not
-                # deadlock explicit same-day consent when no active concern remains.
-                if is_endgame and concerns and has_unsecured and structured_vaccine is not True:
-                    is_endgame = False
+                # No local "is_secured" veto here: the endgame prompt already tells the
+                # detector the tracked concern lists are keyword-derived and often
+                # incomplete, and to trust the full transcript instead. Vetoing the
+                # detector's own is_endgame call with that same unreliable local state
+                # was the same left-hand-right-hand duplication as the mirror gate -
+                # explicit same-day consent should close the session; unsecured concerns
+                # are a Secure-quality scoring problem, not a reason to keep it open.
 
             if is_endgame and outcome == "accepted_literature":
                 structured_literature = self._structured_literature_resolution(result)

--- a/app/services/aims_endgame_service.py
+++ b/app/services/aims_endgame_service.py
@@ -235,9 +235,16 @@ class AimsEndgameService:
                     pass
                 elif structured_literature is False:
                     is_endgame = False
-                elif not self._heuristic_fallback_enabled:
-                    is_endgame = False
                 else:
+                    # structured_literature is None: the detector's structured fields
+                    # weren't present on this call. This text-based cue check is a
+                    # lightweight local verification (no LLM call, no dependency on
+                    # the separate heuristic-fallback feature flag) - it should run
+                    # whenever the structured fields are simply missing, not only
+                    # when heuristic fallback happens to be enabled. Gating it behind
+                    # that flag meant a session with clear, repeated literature+
+                    # follow-up consent could never close in any environment where
+                    # heuristic fallback is off (the deploy default).
                     combined_lower = combined_reply_text.lower()
                     if any(cue in combined_lower for cue in EndGameDetector.PLAN_NEGATIVE_CUES):
                         is_endgame = False

--- a/app/services/aims_state_service.py
+++ b/app/services/aims_state_service.py
@@ -608,8 +608,7 @@ class AimsStateService:
         elif step_current == STEP_SECURE:
             concerns = state.get("parent_concerns") or []
             all_mirrored = all(concern.get("is_mirrored") for concern in concerns) if concerns else True
-            if all_mirrored:
-                state["phase"] = PHASE_SECURE
+            state["phase"] = PHASE_SECURE if all_mirrored else PHASE_INQUIRE_MIRROR
 
         concerns = state.get("parent_concerns") or []
         all_resolved = (

--- a/tests/regression/test_aims_improvements.py
+++ b/tests/regression/test_aims_improvements.py
@@ -122,6 +122,18 @@ def test_secure_stays_in_inquire_mirror_when_unmirrored_concerns_remain():
     assert state["phase"] == "InquireMirror"
 
 
+def test_secure_advances_phase_past_pre_announce_when_unmirrored_concerns_remain():
+    """A clinician who jumps straight from Announce to Secure (skipping Inquire/Mirror
+    entirely) must not leave phase stuck at PreAnnounce forever - that silently blocks
+    AimsEndgameService.check()'s phase guard from ever running the endgame LLM call,
+    even after the person has clearly consented."""
+    h = _state_service()
+    concerns = [{"desc": "x", "topic": "t1", "is_mirrored": False, "is_secured": False}]
+    state = _make_state(phase="PreAnnounce", concerns=concerns)
+    h.update_observational_state(state, "Secure", ["Secure"])
+    assert state["phase"] == "InquireMirror"
+
+
 def test_mirror_plus_inquire_returns_phase_from_secure():
     """Mirror+Inquire compound step should return to InquireMirror from Secure."""
     h = _state_service()

--- a/tests/unit/services/test_endgame_detection_unit.py
+++ b/tests/unit/services/test_endgame_detection_unit.py
@@ -635,6 +635,46 @@ def test_accepted_vaccine_allows_when_all_concerns_are_secured():
     assert result["lines"][0].startswith("Outcome:")
 
 
+def test_accepted_literature_closes_without_structured_fields_when_heuristic_fallback_disabled():
+    """Regression test: AIMS_HEURISTIC_FALLBACK_ENABLED defaults to false and isn't set
+    in staging/prod, so heuristic_fallback_enabled=False is the real deployed condition,
+    not just a test default. When the detector's is_endgame=True/accepted_literature call
+    doesn't happen to include the accepted_materials/accepted_followup structured fields,
+    the lightweight text-cue check (no LLM call, no dependency on the heuristic-fallback
+    feature) must still be able to confirm closure - it must not have been gated behind
+    that unrelated flag such that a session with clear, repeated literature+follow-up
+    consent could never close in the actual deployed environment."""
+    mock_svc = _MockClassifierService(
+        {
+            "is_endgame": True,
+            "resolution_type": "accepted_literature",
+            "summary": "Person is taking a handout home and returning next week.",
+            "reason": "",
+        }
+    )
+    store = {
+        "s9c": {
+            "history": [
+                {
+                    "role": "user",
+                    "content": "Here's a handout, and let's set up a follow-up appointment for next week.",
+                },
+                {
+                    "role": "assistant",
+                    "content": (
+                        "Yes, some written information would be helpful for me to review at home, "
+                        "and a follow-up appointment in a few weeks sounds good."
+                    ),
+                },
+            ],
+            "aims_state": _literature_ready_state(),
+        }
+    }
+    service = _make_endgame_service(mock_svc, heuristic_fallback_enabled=False)
+    result = _run(service.check(store["s9c"], {}, None, "s9c"))
+    assert result is not None, "Clear literature+follow-up consent should close even with heuristic fallback off"
+
+
 def test_accepted_literature_requires_literature_and_followup_evidence():
     """LLM accepted_literature still needs both closure pieces in the transcript."""
     mock_svc = _MockClassifierService(

--- a/tests/unit/services/test_endgame_detection_unit.py
+++ b/tests/unit/services/test_endgame_detection_unit.py
@@ -553,8 +553,14 @@ def test_accepted_vaccine_llm_result_is_trusted_without_heuristic_match_when_con
     assert result is not None, "LLM vaccine acceptance should be enough when concerns are secured"
 
 
-def test_accepted_vaccine_blocks_when_any_concern_is_not_secured():
-    """Even with LLM acceptance, unresolved concerns should block vaccine closure."""
+def test_accepted_vaccine_llm_result_is_trusted_even_when_concern_is_not_secured():
+    """The endgame prompt tells the detector its concern lists are keyword-derived and
+    often stale/incomplete, and to judge from the full transcript instead. A local
+    is_secured=False tracking gap must not veto the detector's own explicit same-day
+    consent determination - that would be the same left-hand-right-hand duplication
+    of authority the mirror gate had, just at the closure layer instead of feedback
+    text. Unsecured concerns are a Secure-quality scoring problem, not a reason to
+    keep the session open indefinitely."""
     mock_svc = _MockClassifierService(
         {
             "is_endgame": True,
@@ -587,7 +593,7 @@ def test_accepted_vaccine_blocks_when_any_concern_is_not_secured():
     }
     service = _make_endgame_service(mock_svc)
     result = _run(service.check(store["s9"], {}, None, "s9"))
-    assert result is None, "Unsecured concerns should block accepted_vaccine closure"
+    assert result is not None, "Explicit same-day consent should close the session regardless of stale local state"
 
 
 def test_accepted_vaccine_allows_when_all_concerns_are_secured():
@@ -795,8 +801,14 @@ def test_deferred_outcome_does_not_trigger_endgame():
 # Tests — pending-concerns guard (Fix 1)
 # ---------------------------------------------------------------------------
 
-def test_unmirrored_concerns_block_endgame():
-    """Endgame must be blocked when concerns exist but some are not mirrored."""
+def test_unmirrored_and_unsecured_concerns_no_longer_block_llm_determined_endgame():
+    """Previously this fixture's unmirrored concerns happened to also be unsecured, so
+    the (now-removed) is_secured veto was doing the actual blocking despite the test's
+    name suggesting a dedicated "unmirrored" gate. Neither an unmirrored nor an
+    unsecured local flag should override the detector's own explicit is_endgame
+    determination anymore - a clinician who kept skipping Mirror/Secure quality
+    should still be able to close on clear same-day consent; that failure shows up
+    in the score, not as an infinite loop."""
     mock_svc = _MockClassifierService(
         {
             "is_endgame": True,
@@ -824,7 +836,7 @@ def test_unmirrored_concerns_block_endgame():
     }
     service = _make_endgame_service(mock_svc)
     result = _run(service.check(store["s12"], {}, None, "s12"))
-    assert result is None, "Endgame should be blocked when unmirrored concerns exist"
+    assert result is not None, "Explicit LLM-determined consent should close the session"
     assert mock_svc.last_history_text != ""
 
 


### PR DESCRIPTION
## Summary
- Remove the local `is_secured` veto that blocked `accepted_vaccine` closure even after clear same-day consent — unmirrored/unsecured concerns are now a scoring penalty, not a hard gate.
- Stop gating the `accepted_literature` text-cue closure check behind the `heuristic_fallback_enabled` flag, which is off by default in every deployed environment.
- Fix the actual root cause found during live re-testing: `update_observational_state`'s plain `STEP_SECURE` branch only advanced `phase` when all concerns were already mirrored (unlike its `STEP_MIRROR_SECURE` sibling, which always advances). When a clinician jumps straight from Announce to Secure without ever Mirroring, `phase` stayed at `PreAnnounce` forever, which silently short-circuited `AimsEndgameService.check()`'s phase guard before the endgame LLM call ever ran — making the first two fixes moot for that path.

## Test plan
- [x] `pytest --ignore=tests/integration -q` (full CI-equivalent suite, all green)
- [x] `ruff check .`, `mypy app`, `bandit -r app -x tests,scripts`
- [x] Live-tested on staging.aimsbot.ca: clinician jumped Announce → Secure (educating before mirroring, "Important" coaching correctly surfaced), person requested literature + a follow-up visit, session correctly reached Endgame with a "👏 Good job!" summary card, 69% overall score, and the Secure bullet calling out the unmirrored pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)