### PR TITLE
Score a never-attempted core AIMS step as 0, not excluded from Overall

### DIFF
--- a/app/services/coach_post.py
+++ b/app/services/coach_post.py
@@ -23,6 +23,26 @@ def _patient_label(session_obj: Dict | None) -> str:
     return message("endgame.labels.patient_possessive_default")
 
 
+_CORE_AIMS_STEPS = ("Announce", "Inquire", "Mirror", "Secure")
+
+
+def _overall_score_pct(running_average: Dict) -> int | None:
+    """Mean of all four core AIMS steps, scaled to 0-100%.
+
+    A step with no recorded turns (e.g. Mirror was never attempted) scores 0,
+    not "excluded from the average" - skipping a core step entirely must cost
+    at least as much as doing it badly, or the Overall score rewards avoiding
+    the harder steps. Returns None only when nothing at all was recorded yet.
+    """
+    if not any(isinstance(running_average.get(s), (int, float)) for s in _CORE_AIMS_STEPS):
+        return None
+    core_avgs = [
+        float(running_average[s]) if isinstance(running_average.get(s), (int, float)) else 0.0
+        for s in _CORE_AIMS_STEPS
+    ]
+    return int(round((sum(core_avgs) / (len(core_avgs) * 3.0)) * 100))
+
+
 class VaccineRelevanceGate:
     """Applies vaccine-relevance gating to a classification payload.
 
@@ -285,13 +305,9 @@ def endgame_title(session_obj: Dict | None, outcome: str = "") -> str:
         return message("endgame.titles.deferred")
     try:
         ra = (session_obj or {}).get("runningAverage") or {}
-        core_avgs = [
-            float(ra[s]) for s in ("Announce", "Inquire", "Mirror", "Secure")
-            if isinstance(ra.get(s), (int, float))
-        ]
-        if not core_avgs:
+        overall = _overall_score_pct(ra)
+        if overall is None:
             return message("endgame.titles.great")
-        overall = sum(core_avgs) / (len(core_avgs) * 3.0) * 100
         if overall >= 85:
             return message("endgame.titles.excellent")
         if overall >= 70:
@@ -346,11 +362,10 @@ def build_endgame_bullets_fallback(session_obj: Dict | None) -> List[str]:
 
     bullets: List[str] = []
 
-    # 1. Overall score from core AIMS steps that were actually used
-    core_avgs = [_avg(s) for s in ("Announce", "Inquire", "Mirror", "Secure")]
-    core_avgs = [a for a in core_avgs if a == a]  # drop NaN
-    if core_avgs:
-        overall_pct = int(round((sum(core_avgs) / (len(core_avgs) * 3.0)) * 100))
+    # 1. Overall score across all four core AIMS steps (a step never attempted
+    # scores 0, it isn't excluded - see _overall_score_pct).
+    overall_pct = _overall_score_pct(ra)
+    if overall_pct is not None:
         bullets.append(message("endgame.overall_score", pct=overall_pct))
 
     # 2. Per-step contextual feedback

--- a/tests/unit/services/test_coach_post_sanitizer.py
+++ b/tests/unit/services/test_coach_post_sanitizer.py
@@ -252,12 +252,21 @@ def test_sanitize_endgame_bullets_handles_empty_quotes_duplicates_and_cap():
 
 
 def test_endgame_title_score_tiers_and_deferred_fallback():
+    def _uniform(score):
+        return {"runningAverage": {s: score for s in ("Announce", "Inquire", "Mirror", "Secure")}}
+
     assert endgame_title(None, outcome="deferred") == "Session Complete"
     assert endgame_title({}) == "🎉 Great job!"
-    assert endgame_title({"runningAverage": {"Announce": 3.0}}) == "🏆 Excellent job!"
-    assert endgame_title({"runningAverage": {"Announce": 2.1}}) == "🎉 Great job!"
-    assert endgame_title({"runningAverage": {"Announce": 1.7}}) == "👏 Good job!"
-    assert endgame_title({"runningAverage": {"Announce": 1.0}}) == "💪 Nice job!"
+    assert endgame_title(_uniform(3.0)) == "🏆 Excellent job!"
+    assert endgame_title(_uniform(2.1)) == "🎉 Great job!"
+    assert endgame_title(_uniform(1.7)) == "👏 Good job!"
+    assert endgame_title(_uniform(1.0)) == "💪 Nice job!"
+
+
+def test_endgame_title_penalizes_core_steps_that_were_never_attempted():
+    """Skipping a core step entirely (e.g. Mirror never happened) must cost at
+    least as much as doing it badly - it must not be excluded from the average."""
+    assert endgame_title({"runningAverage": {"Announce": 3.0}}) == "💪 Nice job!"
 
 
 def test_build_endgame_bullets_fallback_handles_absent_low_mid_high_and_invalid_input():
@@ -275,7 +284,7 @@ def test_build_endgame_bullets_fallback_handles_absent_low_mid_high_and_invalid_
         }
     )
 
-    assert bullets[0] == "Overall AIMS score: 64%"
+    assert bullets[0] == "Overall AIMS score: 48%"
     assert any("Announce 93%" in bullet and "well done" in bullet for bullet in bullets)
     assert any("Inquire 67%" in bullet and "remaining concerns" in bullet for bullet in bullets)
     assert any("Mirror 33%" in bullet and "mirror" in bullet for bullet in bullets)


### PR DESCRIPTION
## Summary
Overall AIMS score averaged only the core steps that had recorded turns, so a session that skipped Inquire and Mirror entirely still got credited as if only Announce and Secure existed. A clinician who never even attempted the harder steps could score better on Overall than the per-step breakdown implied — e.g. Announce 67% + Secure 44% averaged to 56% overall while Inquire and Mirror never happened at all.

This contradicts the standing rule that skipping Mirror is the worst mistake a clinician can make (already reflected in the Secure line's own penalty, but not in Overall). Every core step (Announce/Inquire/Mirror/Secure) now always contributes to the denominator; an unattempted step scores 0.

## Test plan
- [x] `pytest --ignore=tests/integration -q` (full CI-equivalent suite, all green)
- [x] `ruff check .`, `mypy app`, `bandit -r app -x tests,scripts`
- [x] Live-tested on staging.aimsbot.ca: a Zia/Nathaniel scenario with Announce, two Secure-before-Mirror turns, one Mirror, and Inquire never attempted at all now correctly scores Overall 44% (previously would have been 59%, excluding the never-attempted Inquire step) and downgrades the title from "Good job!" to "Nice job!" accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)