### PR TITLE
Combine title+score into one line, add honest low-score tiers, bold coach headings

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -124,14 +124,14 @@ cot = "full"
 
 # Specify a CSS file that can be used to customize the user interface.
 # The CSS file can be served from the public directory or via an external link.
-custom_css = "/public/aimsbot.css?v=20260729-endgame-scroll"
+custom_css = "/public/aimsbot.css?v=20260809-coach-headings"
 
 # Specify additional attributes for a custom CSS file
 # custom_css_attributes = "media=\"print\""
 
 # Specify a JavaScript file that can be used to customize the user interface.
 # The JavaScript file can be served from the public directory.
-custom_js = "/public/aimsbot-ui.js?v=20260729-endgame-scroll"
+custom_js = "/public/aimsbot-ui.js?v=20260809-coach-headings"
 
 # The style of alert boxes. Can be "classic" or "modern".
 alert_style = "classic"

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -11,8 +11,8 @@
   "coaching": {
     "deferred_nudge": "Nudge: The patient is deferring. Try offering specific literature or a follow-up visit to reach a clear AIMS resolution.",
     "feedback": "Feedback: {feedback}",
-    "feedback_group_header": "{label}:",
-    "step_group_header": "{step}:",
+    "feedback_group_header": "**{label}:**",
+    "step_group_header": "**{step}:**",
     "labels": {
       "praise": [
         "Good job!",
@@ -30,12 +30,12 @@
       "important": "Important"
     },
     "feedback_group": "Feedback",
-    "tip": "Tip: {tip}",
+    "tip": "**Tip:** {tip}",
     "phase_prefix": "Conversation phase:",
     "section_title": "Coaching",
     "scenario_complete": "Scenario complete",
     "scenario_complete_marked": "\u2705 Scenario complete",
-    "outcome": "Outcome: {summary}"
+    "outcome": "**Outcome:** {summary}"
   },
   "state_feedback": {
     "announce_after_inquiry": "Avoid moving to Announce after inquiry before all concerns are mirrored.",
@@ -79,12 +79,14 @@
     },
     "titles": {
       "deferred": "Session Complete",
-      "excellent": "\ud83c\udfc6 Excellent job!",
-      "great": "\ud83c\udf89 Great job!",
-      "good": "\ud83d\udc4f Good job!",
-      "nice": "\ud83d\udcaa Nice job!"
+      "no_data": "\ud83c\udf89 Great job!",
+      "excellent": "\ud83c\udfc6 Excellent job \u2014 {pct}% overall",
+      "great": "\ud83c\udf89 Great job \u2014 {pct}% overall",
+      "good": "\ud83d\udc4f Good job \u2014 {pct}% overall",
+      "keep_practicing": "\ud83d\udcaa Keep practicing \u2014 {pct}% overall",
+      "needs_work": "\ud83d\udccb Needs work \u2014 {pct}% overall"
     },
-    "overall_score": "Overall AIMS score: {pct}%",
+    "overall_score": "**Overall AIMS score:** {pct}%",
     "fallback_bullets": {
       "default": [
         "Announce: lead with a short, non-pushy recommendation and invite input.",

--- a/app/services/aims_endgame_service.py
+++ b/app/services/aims_endgame_service.py
@@ -276,7 +276,11 @@ class AimsEndgameService:
                 self._logger.debug("Summary analysis failed for endgame coach post: %s", e)
 
             try:
-                fallback_bullets = build_endgame_bullets_fallback(session_obj)
+                # include_overall_score=False: the score is already folded into
+                # `title` (see endgame_title), so this would otherwise duplicate it.
+                fallback_bullets = build_endgame_bullets_fallback(
+                    session_obj, include_overall_score=False
+                )
                 if fallback_bullets:
                     lines.extend(fallback_bullets)
             except Exception as e:

--- a/app/services/coach_post.py
+++ b/app/services/coach_post.py
@@ -292,14 +292,17 @@ def sanitize_endgame_bullets(lines: List[str]) -> List[str]:
 
 
 def endgame_title(session_obj: Dict | None, outcome: str = "") -> str:
-    """Return a score-calibrated celebratory title for the end-of-session card.
+    """Return a score-calibrated title for the end-of-session card, with the
+    Overall AIMS score folded into the same line instead of shown separately.
 
-    Overall score (mean of core AIMS step averages, scaled to 0-100%):
-      >= 85%  -> "🎉 Excellent job!"
-      >= 70%  -> "🎉 Great job!"
-      >= 55%  -> "🎉 Good job!"
-      <  55%  -> "🎉 Nice job!"
-    Falls back to 'Great job!' when no score data is available.
+    Overall score (mean of all four core AIMS step averages, scaled to
+    0-100% - a step never attempted scores 0, see _overall_score_pct):
+      >= 85%  -> "🏆 Excellent job — N% overall"
+      >= 70%  -> "🎉 Great job — N% overall"
+      >= 55%  -> "👏 Good job — N% overall"
+      >= 35%  -> "💪 Keep practicing — N% overall"    (encouraging, not celebratory)
+      <  35%  -> "📋 Needs work — N% overall"          (encouraging, not celebratory)
+    Falls back to a plain "Great job!" (no score) when no score data is available.
     """
     if outcome == "deferred":
         return message("endgame.titles.deferred")
@@ -307,24 +310,32 @@ def endgame_title(session_obj: Dict | None, outcome: str = "") -> str:
         ra = (session_obj or {}).get("runningAverage") or {}
         overall = _overall_score_pct(ra)
         if overall is None:
-            return message("endgame.titles.great")
+            return message("endgame.titles.no_data")
         if overall >= 85:
-            return message("endgame.titles.excellent")
-        if overall >= 70:
-            return message("endgame.titles.great")
-        if overall >= 55:
-            return message("endgame.titles.good")
-        return message("endgame.titles.nice")
+            tier = "excellent"
+        elif overall >= 70:
+            tier = "great"
+        elif overall >= 55:
+            tier = "good"
+        elif overall >= 35:
+            tier = "keep_practicing"
+        else:
+            tier = "needs_work"
+        return message(f"endgame.titles.{tier}", pct=overall)
     except Exception as e:
         logger.debug(f"Error determining endgame title: {e}")
-        return message("endgame.titles.great")
+        return message("endgame.titles.no_data")
 
 
-def build_endgame_bullets_fallback(session_obj: Dict | None) -> List[str]:
+def build_endgame_bullets_fallback(
+    session_obj: Dict | None, *, include_overall_score: bool = True
+) -> List[str]:
     """Contextual, score-aware feedback bullets for the end-of-session Great Job card.
 
-    Shows overall AIMS score percentage followed by per-step feedback calibrated
-    to the clinician's actual performance in this session.
+    Shows overall AIMS score percentage (unless include_overall_score=False - the
+    score is already folded into endgame_title()'s own line, so check() omits the
+    duplicate here) followed by per-step feedback calibrated to the clinician's
+    actual performance in this session.
     """
     # Score range helpers
     _HIGH = 2.4    # >= 80%
@@ -364,9 +375,10 @@ def build_endgame_bullets_fallback(session_obj: Dict | None) -> List[str]:
 
     # 1. Overall score across all four core AIMS steps (a step never attempted
     # scores 0, it isn't excluded - see _overall_score_pct).
-    overall_pct = _overall_score_pct(ra)
-    if overall_pct is not None:
-        bullets.append(message("endgame.overall_score", pct=overall_pct))
+    if include_overall_score:
+        overall_pct = _overall_score_pct(ra)
+        if overall_pct is not None:
+            bullets.append(message("endgame.overall_score", pct=overall_pct))
 
     # 2. Per-step contextual feedback
     secure_before_mirror_count = int(session_obj.get("secureBeforeMirrorCount", 0) or 0)
@@ -400,13 +412,13 @@ def build_endgame_bullets_fallback(session_obj: Dict | None) -> List[str]:
                     persona_label=persona_label,
                 )
             if c == 0 or a != a:
-                bullets.append(f"Secure: {unmirrored_text}")
+                bullets.append(f"Secure 0% - {unmirrored_text}")
             else:
                 bullets.append(f"Secure {_pct(a)}% - {unmirrored_text}")
             continue
 
         if c == 0 or a != a:  # step not used or no score data
-            bullets.append(f"{step_name}: {_step_message('absent')}")
+            bullets.append(f"{step_name} 0% - {_step_message('absent')}")
         elif a >= _HIGH:
             bullets.append(f"{step_name} {_pct(a)}% - {_step_message('high')}")
         elif a >= _MID:

--- a/app/services/coaching_display.py
+++ b/app/services/coaching_display.py
@@ -113,7 +113,7 @@ def step_feedback_label(
 def _feedback_line(tone: Any, label: str, feedback: str) -> str:
     if tone == "praise":
         return f"{label} {feedback}"
-    return f"{label}: {feedback}"
+    return f"**{label}:** {feedback}"
 
 
 def _feedback_group_label(item: Mapping[str, Any], fallback_step: str = "") -> str:

--- a/public/aimsbot-ui.js
+++ b/public/aimsbot-ui.js
@@ -10,7 +10,7 @@
   if (window.__aimsbotCustomJsInitialized) return;
   window.__aimsbotCustomJsInitialized = true;
 
-  const assetVersion = "20260729-endgame-scroll";
+  const assetVersion = "20260809-coach-headings";
   window.AIMSBotUI = window.AIMSBotUI || {};
   window.AIMSBotUI.pendingWindowMessages = window.AIMSBotUI.pendingWindowMessages || [];
   window.AIMSBotUI.handleWindowMessagePayload =

--- a/public/aimsbot.css
+++ b/public/aimsbot.css
@@ -407,6 +407,14 @@ body.aimsbot-shell .aimsbot-message-list {
   margin-top: 0.25rem !important;
 }
 
+/* Coach message headings ("Outcome:", "Important:", "Tip:", step names like
+   "Secure:") are wrapped in markdown bold by the backend. Browser-default
+   bold (700) reads too heavy next to body copy, so dial it back to a
+   noticeably heftier-than-body weight without going full bold. */
+.aims-message-bubble strong {
+  font-weight: 600 !important;
+}
+
 .aims-message-bubble strong:first-child {
   display: inline-block !important;
   margin-bottom: 0.25rem !important;

--- a/tests/regression/test_aims_replay_regressions.py
+++ b/tests/regression/test_aims_replay_regressions.py
@@ -228,9 +228,9 @@ async def test_replay_split_acceptance_requires_second_turn():
         ctx=ctx,
     )
 
-    assert result2["coach_post"]["title"].endswith("job!")
+    assert "% overall" in result2["coach_post"]["title"]
     assert memory_store[session_id][KEY_GAME_OVER] is True
-    assert memory_store[session_id][KEY_COACH_POST]["title"].endswith("job!")
+    assert "% overall" in memory_store[session_id][KEY_COACH_POST]["title"]
 
 
 @pytest.mark.asyncio
@@ -415,7 +415,6 @@ async def test_replay_mixed_resolution_vaccine_today_plus_literature_ends_as_vac
         ctx=ctx,
     )
 
-    assert result["coach_post"]["title"].endswith("job!")
+    assert "% overall" in result["coach_post"]["title"]
     assert "Outcome:" in result["coach_post"]["lines"][0]
-    assert any("Overall AIMS score:" in line for line in result["coach_post"]["lines"])
     assert memory_store[session_id][KEY_GAME_OVER] is True

--- a/tests/unit/services/chainlit/test_chainlit_orchestrator.py
+++ b/tests/unit/services/chainlit/test_chainlit_orchestrator.py
@@ -11,7 +11,7 @@ from app.services.chainlit.orchestrator import ChainlitOrchestrator
 
 
 def _has_praise_line(text: str, step: str, feedback: str) -> bool:
-    return f"{step}:\n" in text and any(
+    return f"**{step}:**\n" in text and any(
         f"{label} {feedback}" in text for label in message_list("coaching.labels.praise")
     )
 
@@ -485,7 +485,7 @@ async def test_process_backend_response_dispatches_coaching_reply_and_coach_post
     assert mock_services["session"].history == [
         {
             "role": "coach",
-            "content": "Announce:\n- Feedback: Clear recommendation.\n- Tip: Ask how that sounds.",
+            "content": "**Announce:**\n- Feedback: Clear recommendation.\n- **Tip:** Ask how that sounds.",
             "coaching_data": coaching,
         },
         {"role": "assistant", "content": "I need to understand more."},
@@ -534,7 +534,7 @@ async def test_process_backend_response_prefers_step_feedback_over_raw_tip(
     coach_text = mock_services["session"].history[0]["content"]
     assert _has_praise_line(coach_text, "Inquire", "You opened with a broad concern question.")
     assert "praise:" not in coach_text.lower()
-    assert "Secure:\n- Tip: Pause before moving into reassurance." in coach_text
+    assert "**Secure:**\n- **Tip:** Pause before moving into reassurance." in coach_text
     assert "Tip: Try leading with an open question." not in coach_text
 
 
@@ -570,7 +570,7 @@ async def test_process_backend_response_shows_tip_with_praise_only_step_feedback
     assert _has_praise_line(coach_text, "Secure", "You led with a strong autonomy statement.")
     assert "praise:" not in coach_text.lower()
     assert (
-        "Tip: Ask a single, open-ended question to check for understanding."
+        "**Tip:** Ask a single, open-ended question to check for understanding."
         in coach_text
     )
 

--- a/tests/unit/services/chainlit/test_chainlit_services.py
+++ b/tests/unit/services/chainlit/test_chainlit_services.py
@@ -23,7 +23,7 @@ from app.services.chainlit.ui_handler import UIHandler
 
 
 def _has_praise_line(text: str, step: str, feedback: str) -> bool:
-    return f"{step}:\n" in text and any(
+    return f"**{step}:**\n" in text and any(
         f"{label} {feedback}" in text for label in message_list("coaching.labels.praise")
     )
 
@@ -150,7 +150,7 @@ def test_ui_handler_format_coaching_message_uses_structured_payload():
     assert "- Secure:" not in formatted
     assert _has_praise_line(formatted, "Secure", "You affirmed autonomy clearly.")
     assert "secure: praise:" not in formatted.lower()
-    assert "- Tip: Offer a concrete next step." in formatted
+    assert "- **Tip:** Offer a concrete next step." in formatted
 
 
 def test_ui_handler_format_coaching_message_prefers_feedback_items():
@@ -172,7 +172,7 @@ def test_ui_handler_format_coaching_message_prefers_feedback_items():
         }
     )
 
-    assert "Inquire:\n- Tip: Ask one open concern question, then pause." in formatted
+    assert "**Inquire:**\n- **Tip:** Ask one open concern question, then pause." in formatted
     assert "Legacy reason should not be shown" not in formatted
     assert "Legacy tip should not show" not in formatted
 
@@ -230,8 +230,8 @@ def test_ui_handler_format_coaching_message_groups_multiple_step_feedback_items(
         f"{label} You ended with a collaborative check-in question." in formatted
         for label in message_list("coaching.labels.praise")
     )
-    assert formatted.count("Mirror:\n") == 1
-    assert formatted.count("Secure:\n") == 1
+    assert formatted.count("**Mirror:**\n") == 1
+    assert formatted.count("**Secure:**\n") == 1
 
 
 def test_ui_handler_format_coaching_message_keeps_step_improvement_with_praise():
@@ -258,8 +258,8 @@ def test_ui_handler_format_coaching_message_keeps_step_improvement_with_praise()
     )
 
     assert _has_praise_line(formatted, "Mirror", "You named the person's concern.")
-    assert "Mirror:\n" in formatted
-    assert "- Tip: Slow down and pause after key facts to check understanding." in formatted
+    assert "**Mirror:**\n" in formatted
+    assert "- **Tip:** Slow down and pause after key facts to check understanding." in formatted
 
 
 def test_ui_handler_format_coaching_message_labels_model_generated_mirror_tip_as_important():
@@ -289,8 +289,8 @@ def test_ui_handler_format_coaching_message_labels_model_generated_mirror_tip_as
     )
 
     assert _has_praise_line(formatted, "Mirror", "You named the person's concern.")
-    assert "Mirror:\n" in formatted
-    assert "- Important: Mirror the timing concern before offering education." in formatted
+    assert "**Mirror:**\n" in formatted
+    assert "- **Important:** Mirror the timing concern before offering education." in formatted
 
 
 def test_ui_handler_format_coaching_message_labels_secure_before_mirror_as_important():
@@ -310,7 +310,7 @@ def test_ui_handler_format_coaching_message_labels_secure_before_mirror_as_impor
         }
     )
 
-    assert "Secure:\n- Important: Mirror the active concern before offering more education." in formatted
+    assert "**Secure:**\n- **Important:** Mirror the active concern before offering more education." in formatted
     assert "Tip: Mirror the active concern" not in formatted
 
 

--- a/tests/unit/services/test_coach_feedback_history_service.py
+++ b/tests/unit/services/test_coach_feedback_history_service.py
@@ -5,7 +5,7 @@ from app.services.coach_feedback_history_service import CoachFeedbackHistoryServ
 
 
 def _has_praise_line(text: str, step: str, feedback: str) -> bool:
-    return f"{step}:\n" in text and any(
+    return f"**{step}:**\n" in text and any(
         f"{label} {feedback}" in text for label in message_list("coaching.labels.praise")
     )
 
@@ -128,9 +128,9 @@ def test_append_uses_step_feedback_and_deferred_nudge():
     )
 
     text = mem[SESSION_HISTORY][0]["content"]
-    assert "Mirror:\n" in text
+    assert "**Mirror:**\n" in text
     assert "You mirrored the concern." in text
-    assert "Inquire:\n" in text
+    assert "**Inquire:**\n" in text
     assert "Ask what worries them most." in text
     assert "Nudge: The patient is deferring." in text
     assert "This should not show" not in text
@@ -163,7 +163,7 @@ def test_append_shows_tip_when_step_feedback_is_praise_only():
     text = mem[SESSION_HISTORY][0]["content"]
     assert _has_praise_line(text, "Secure", "You affirmed autonomy clearly.")
     assert "praise:" not in text.lower()
-    assert "- Tip: Ask one open-ended check-in question." in text
+    assert "- **Tip:** Ask one open-ended check-in question." in text
 
 
 def test_append_prefers_feedback_items_over_legacy_reasons():
@@ -193,7 +193,7 @@ def test_append_prefers_feedback_items_over_legacy_reasons():
     )
 
     text = mem[SESSION_HISTORY][0]["content"]
-    assert "Inquire:\n- Tip: Ask one open concern question, then pause." in text
+    assert "**Inquire:**\n- **Tip:** Ask one open concern question, then pause." in text
     assert "Legacy reason should not drive display" not in text
     assert "Legacy tip should not show" not in text
 
@@ -254,8 +254,8 @@ def test_append_groups_multiple_same_step_praise_in_display_only():
         "You tailored the education to their question.",
     )
     assert "You ended with a collaborative check-in question." in text
-    assert text.count("Mirror:\n") == 1
-    assert text.count("Secure:\n") == 1
+    assert text.count("**Mirror:**\n") == 1
+    assert text.count("**Secure:**\n") == 1
     assert len(coach_entry["coaching_data"]["feedback_items"]) == 4
 
 

--- a/tests/unit/services/test_coach_post_sanitizer.py
+++ b/tests/unit/services/test_coach_post_sanitizer.py
@@ -252,21 +252,25 @@ def test_sanitize_endgame_bullets_handles_empty_quotes_duplicates_and_cap():
 
 
 def test_endgame_title_score_tiers_and_deferred_fallback():
+    """Title folds the Overall score into the same line; the bottom two tiers
+    (keep_practicing, needs_work) use encouraging-but-not-celebratory language
+    and emoji, since a weak score should not read as "job!" praise."""
     def _uniform(score):
         return {"runningAverage": {s: score for s in ("Announce", "Inquire", "Mirror", "Secure")}}
 
     assert endgame_title(None, outcome="deferred") == "Session Complete"
     assert endgame_title({}) == "🎉 Great job!"
-    assert endgame_title(_uniform(3.0)) == "🏆 Excellent job!"
-    assert endgame_title(_uniform(2.1)) == "🎉 Great job!"
-    assert endgame_title(_uniform(1.7)) == "👏 Good job!"
-    assert endgame_title(_uniform(1.0)) == "💪 Nice job!"
+    assert endgame_title(_uniform(3.0)) == "🏆 Excellent job — 100% overall"
+    assert endgame_title(_uniform(2.1)) == "🎉 Great job — 70% overall"
+    assert endgame_title(_uniform(1.7)) == "👏 Good job — 57% overall"
+    assert endgame_title(_uniform(1.2)) == "💪 Keep practicing — 40% overall"
+    assert endgame_title(_uniform(0.5)) == "📋 Needs work — 17% overall"
 
 
 def test_endgame_title_penalizes_core_steps_that_were_never_attempted():
     """Skipping a core step entirely (e.g. Mirror never happened) must cost at
     least as much as doing it badly - it must not be excluded from the average."""
-    assert endgame_title({"runningAverage": {"Announce": 3.0}}) == "💪 Nice job!"
+    assert endgame_title({"runningAverage": {"Announce": 3.0}}) == "📋 Needs work — 25% overall"
 
 
 def test_build_endgame_bullets_fallback_handles_absent_low_mid_high_and_invalid_input():
@@ -284,11 +288,25 @@ def test_build_endgame_bullets_fallback_handles_absent_low_mid_high_and_invalid_
         }
     )
 
-    assert bullets[0] == "Overall AIMS score: 48%"
+    assert bullets[0] == "**Overall AIMS score:** 48%"
     assert any("Announce 93%" in bullet and "well done" in bullet for bullet in bullets)
     assert any("Inquire 67%" in bullet and "remaining concerns" in bullet for bullet in bullets)
     assert any("Mirror 33%" in bullet and "mirror" in bullet for bullet in bullets)
-    assert any(bullet.startswith("Secure:") and "absent" not in bullet for bullet in bullets)
+    assert any(bullet.startswith("Secure 0%") and "absent" not in bullet for bullet in bullets)
+
+
+def test_build_endgame_bullets_fallback_can_omit_overall_score_line():
+    """AimsEndgameService.check() passes include_overall_score=False because the
+    score is already folded into endgame_title() - it must not appear twice."""
+    bullets = build_endgame_bullets_fallback(
+        {
+            "perStepCounts": {"Announce": 1, "Inquire": 1, "Mirror": 1, "Secure": 1},
+            "runningAverage": {"Announce": 2.0, "Inquire": 2.0, "Mirror": 2.0, "Secure": 2.0},
+        },
+        include_overall_score=False,
+    )
+
+    assert not any("Overall AIMS score" in bullet for bullet in bullets)
 
 
 def test_build_endgame_bullets_fallback_personalizes_with_persona_and_patient_names():

--- a/tests/unit/services/test_endgame_detection_unit.py
+++ b/tests/unit/services/test_endgame_detection_unit.py
@@ -406,7 +406,7 @@ def test_classifier_not_resolved_resolution_does_not_skip_post_reply_acceptance(
     )
 
     assert result is not None
-    assert result["lines"][0] == "Outcome: Sarah agreed to vaccinate today."
+    assert result["lines"][0] == "**Outcome:** Sarah agreed to vaccinate today."
     assert mock_svc.calls == 1
 
 
@@ -632,7 +632,7 @@ def test_accepted_vaccine_allows_when_all_concerns_are_secured():
     result = _run(service.check(store["s9b"], {}, None, "s9b"))
     assert result is not None
     assert "Great job" in result["title"]
-    assert result["lines"][0].startswith("Outcome:")
+    assert result["lines"][0].startswith("**Outcome:**")
 
 
 def test_accepted_literature_closes_without_structured_fields_when_heuristic_fallback_disabled():
@@ -1360,7 +1360,7 @@ def test_structured_accepted_literature_fields_bypass_english_cue_validation():
     service = _make_endgame_service(mock_svc)
     result = _run(service.check(store["s15_structured_lit"], {}, None, "s15_structured_lit"))
     assert result is not None
-    assert result["lines"][0] == "Outcome: Person agreed to review materials and continue later."
+    assert result["lines"][0] == "**Outcome:** Person agreed to review materials and continue later."
 
 
 def test_endgame_personalizes_generic_summary_subject_when_persona_known():
@@ -1402,7 +1402,7 @@ def test_endgame_personalizes_generic_summary_subject_when_persona_known():
 
     assert result is not None
     assert result["lines"][0] == (
-        "Outcome: Sarah agreed to take home an information sheet and return for follow-up."
+        "**Outcome:** Sarah agreed to take home an information sheet and return for follow-up."
     )
 
 
@@ -1581,7 +1581,7 @@ def test_structured_vaccine_closure_overrides_stale_unsecured_state():
         )
     )
     assert result is not None
-    assert result["lines"][0] == "Outcome: Person agreed to give the MMR booster today."
+    assert result["lines"][0] == "**Outcome:** Person agreed to give the MMR booster today."
 
 
 def test_accepted_literature_closure_uses_latest_exchange_not_old_safety_risk_mirror():
@@ -1910,8 +1910,8 @@ def test_endgame_uses_summary_analysis_bullets_when_available():
     result = _run(service.check(store["s18"], {}, session_obj, "s18"))
 
     assert result is not None
-    assert result["lines"][0] == "Outcome: Person accepted vaccination today."
-    assert any("Overall AIMS score:" in line for line in result["lines"])
+    assert result["lines"][0] == "**Outcome:** Person accepted vaccination today."
+    assert "% overall" in result["title"]
     assert "LLM bullet 1" in result["lines"]
     assert "LLM bullet 2" in result["lines"]
 
@@ -1949,8 +1949,8 @@ def test_endgame_ignores_thin_summary_analysis_and_keeps_deterministic_card():
     result = _run(service.check(store["s18b"], {}, session_obj, "s18b"))
 
     assert result is not None
-    assert result["lines"][0] == "Outcome: Person accepted vaccination today."
-    assert any("Overall AIMS score:" in line for line in result["lines"])
+    assert result["lines"][0] == "**Outcome:** Person accepted vaccination today."
+    assert "% overall" in result["title"]
     assert all("Thin summary only" not in line for line in result["lines"])
 
 
@@ -2025,5 +2025,5 @@ def test_endgame_falls_back_to_deterministic_bullets_when_summary_analysis_fails
     result = _run(service.check(store["s19"], {}, session_obj, "s19"))
 
     assert result is not None
-    assert result["lines"][0] == "Outcome: Person accepted vaccination today."
-    assert any("Overall AIMS score:" in line for line in result["lines"])
+    assert result["lines"][0] == "**Outcome:** Person accepted vaccination today."
+    assert "% overall" in result["title"]


### PR DESCRIPTION
## Summary
- Fold the Overall AIMS score into the end-of-session title line instead of showing it as a separate, redundant bullet right below (e.g. "💪 Keep practicing — 46% overall").
- Split the old catch-all "<55% → Nice job!" tier into two honest, non-celebratory bands: `>=35% → 💪 Keep practicing`, `<35% → 📋 Needs work`. A weak or zero-effort session (e.g. Inquire and Mirror never attempted) should not read as cheerful praise.
- Bold the short label prefixes in coach messages (`**Outcome:**`, `**Tip:**`, `**Important:**`, step names like `**Secure:**`) via markdown, with a CSS rule (`font-weight: 600`) that's heftier than body text without going full browser-bold (700).
- Bump the static asset cache-busting version so the CSS/JS changes actually reach users.

## Test plan
- [x] `pytest --ignore=tests/integration -q` (full CI-equivalent suite, all green)
- [x] `ruff check .`, `mypy app`, `bandit -r app -x tests,scripts`
- [x] Live-tested on staging.aimsbot.ca: a Jasmine/Sophia scenario with Announce, Secure-before-Mirror, and Inquire never attempted correctly renders "💪 Keep practicing — 46% overall" as one line (no separate score bullet), and coach headings ("Announce:", "Tip:", "Outcome:") render bold at the lighter weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)