### PR TITLE
Rename endgame card to Summary; disable composer once session ends

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -124,14 +124,14 @@ cot = "full"
 
 # Specify a CSS file that can be used to customize the user interface.
 # The CSS file can be served from the public directory or via an external link.
-custom_css = "/public/aimsbot.css?v=20260809-coach-headings"
+custom_css = "/public/aimsbot.css?v=20260809-session-lock"
 
 # Specify additional attributes for a custom CSS file
 # custom_css_attributes = "media=\"print\""
 
 # Specify a JavaScript file that can be used to customize the user interface.
 # The JavaScript file can be served from the public directory.
-custom_js = "/public/aimsbot-ui.js?v=20260809-coach-headings"
+custom_js = "/public/aimsbot-ui.js?v=20260809-session-lock"
 
 # The style of alert boxes. Can be "classic" or "modern".
 alert_style = "classic"

--- a/app/constants.py
+++ b/app/constants.py
@@ -131,6 +131,7 @@ MSG_NEW_CHAT = "new_chat"
 MSG_INTRO_CONTINUE = "aims_intro_continue"
 MSG_PERSONA_NAME = "aims_persona_name"
 MSG_THREAD_BOUND = "aims_thread_bound"
+MSG_SESSION_ENDED = "aims_session_ended"
 
 # OAuth Providers
 PROVIDER_GOOGLE = "google"

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -33,6 +33,7 @@
     "tip": "**Tip:** {tip}",
     "phase_prefix": "Conversation phase:",
     "section_title": "Coaching",
+    "summary_section_title": "Summary",
     "scenario_complete": "Scenario complete",
     "scenario_complete_marked": "\u2705 Scenario complete",
     "outcome": "**Outcome:** {summary}"

--- a/app/services/chainlit/orchestrator.py
+++ b/app/services/chainlit/orchestrator.py
@@ -18,6 +18,7 @@ from app.constants import (
     MSG_INTRO_REQUIRED,
     MSG_DUPLICATE_TAB,
     MSG_PERSONA_NAME,
+    MSG_SESSION_ENDED,
     MSG_THREAD_BOUND,
 )
 from app.message_catalog import message as catalog_message, message_list
@@ -232,6 +233,7 @@ class ChainlitOrchestrator:
             )
             self.session.session_ended = True
             self.session.history = []
+            await self.ui.send_window_message({"type": MSG_SESSION_ENDED})
             await self.ui.show_error(catalog_message("chainlit.report_success"))
         except Exception as e:
             await self.ui.show_error(catalog_message("chainlit.report_error", error=str(e)))
@@ -452,6 +454,8 @@ class ChainlitOrchestrator:
             title = coach_post.get("title") or catalog_message("coaching.scenario_complete_marked")
             combined = "\n".join([title, *(coach_post.get("lines") or [])])
             await self.ui.send_coach_message(combined)
+            self.session.session_ended = True
+            await self.ui.send_window_message({"type": MSG_SESSION_ENDED})
 
         self.session.history = history
 

--- a/app/services/chainlit/ui_handler.py
+++ b/app/services/chainlit/ui_handler.py
@@ -94,7 +94,7 @@ class UIHandler:
         title = (
             scenario_complete
             if any(scenario_complete in p for p in parts)
-            else message("coaching.section_title")
+            else message("coaching.summary_section_title")
         )
         return UIHandler._format_parts(title, parts)
 

--- a/public/aimsbot-ui.js
+++ b/public/aimsbot-ui.js
@@ -10,7 +10,7 @@
   if (window.__aimsbotCustomJsInitialized) return;
   window.__aimsbotCustomJsInitialized = true;
 
-  const assetVersion = "20260809-coach-headings";
+  const assetVersion = "20260809-session-lock";
   window.AIMSBotUI = window.AIMSBotUI || {};
   window.AIMSBotUI.pendingWindowMessages = window.AIMSBotUI.pendingWindowMessages || [];
   window.AIMSBotUI.handleWindowMessagePayload =

--- a/public/js/aimsbot/core.js
+++ b/public/js/aimsbot/core.js
@@ -50,6 +50,28 @@
     });
   };
 
+  app.state.sessionEnded = app.state.sessionEnded || false;
+
+  // Re-applied on every decorateShell() pass (including the persistent
+  // MutationObserver in message-roles.js) since Chainlit can re-render the
+  // composer after the session has already ended.
+  app.applyComposerLockState = function () {
+    if (!app.state.sessionEnded) return;
+    document.querySelectorAll(".aimsbot-composer-input").forEach(function (textarea) {
+      if (textarea.disabled) return;
+      textarea.disabled = true;
+      textarea.placeholder = app.t("session.endedPlaceholder");
+    });
+    document.querySelectorAll(".aimsbot-composer button").forEach(function (button) {
+      button.disabled = true;
+    });
+  };
+
+  app.lockComposer = function () {
+    app.state.sessionEnded = true;
+    app.applyComposerLockState();
+  };
+
   app.prevent = function (event) {
     if (!event) return;
     event.preventDefault();
@@ -106,6 +128,8 @@
     document.querySelectorAll("aside").forEach(function (aside) {
       aside.classList.add("aimsbot-sidebar");
     });
+
+    app.applyComposerLockState();
   };
 
   app.decorateNativeDialogs = function () {

--- a/public/js/aimsbot/i18n.js
+++ b/public/js/aimsbot/i18n.js
@@ -38,7 +38,8 @@
       logoutDescription: "Are you sure you want to logout? This will end your current session.",
       logoutConfirm: "Logout",
       loggingOut: "Logging out",
-      logoutMatchers: ["logout", "sign out"]
+      logoutMatchers: ["logout", "sign out"],
+      endedPlaceholder: "This session has ended. Start a new scenario to continue practicing."
     },
     infographic: {
       title: "Review the AIMS approach",

--- a/public/js/aimsbot/message-roles.js
+++ b/public/js/aimsbot/message-roles.js
@@ -264,6 +264,7 @@
   function refreshMessages() {
     injectDataAuthors();
     keepLatestMessageVisible();
+    if (app.applyComposerLockState) app.applyComposerLockState();
   }
 
     let debounce = null;

--- a/public/js/aimsbot/window-events.js
+++ b/public/js/aimsbot/window-events.js
@@ -32,6 +32,8 @@
       if (app.messageRoles && app.messageRoles.injectDataAuthors) {
         app.messageRoles.injectDataAuthors();
       }
+    } else if (type === "aims_session_ended") {
+      if (app.lockComposer) app.lockComposer();
     } else if (type === "aims_thread_bound" && data.threadId) {
       const path = window.location.pathname;
       if (path === "/chat" || path === "/chat/") {

--- a/tests/unit/services/chainlit/test_chainlit_orchestrator.py
+++ b/tests/unit/services/chainlit/test_chainlit_orchestrator.py
@@ -465,6 +465,7 @@ async def test_process_backend_response_dispatches_coaching_reply_and_coach_post
     mock_services["ui"].send_coach_message = AsyncMock()
     mock_services["ui"].send_coaching_message = AsyncMock()
     mock_services["ui"].send_assistant_reply = AsyncMock()
+    mock_services["ui"].send_window_message = AsyncMock()
 
     coaching = {
         "step": "Announce",
@@ -496,6 +497,10 @@ async def test_process_backend_response_dispatches_coaching_reply_and_coach_post
     )
     mock_services["ui"].send_assistant_reply.assert_awaited_once_with(
         "I need to understand more.", author_name="Sarah"
+    )
+    assert mock_services["session"].session_ended is True
+    mock_services["ui"].send_window_message.assert_awaited_once_with(
+        {"type": "aims_session_ended"}
     )
 
 
@@ -631,6 +636,7 @@ async def test_process_backend_response_handles_empty_coaching_and_default_coach
     mock_services["ui"].send_coach_message = AsyncMock()
     mock_services["ui"].send_coaching_message = AsyncMock()
     mock_services["ui"].send_assistant_reply = AsyncMock()
+    mock_services["ui"].send_window_message = AsyncMock()
 
     await orchestrator._process_backend_response(
         {
@@ -644,6 +650,10 @@ async def test_process_backend_response_handles_empty_coaching_and_default_coach
     mock_services["ui"].send_coaching_message.assert_not_awaited()
     mock_services["ui"].send_coach_message.assert_awaited_once_with(
         "✅ Scenario complete\nLine"
+    )
+    assert mock_services["session"].session_ended is True
+    mock_services["ui"].send_window_message.assert_awaited_once_with(
+        {"type": "aims_session_ended"}
     )
 
 
@@ -981,6 +991,7 @@ async def test_handle_report_issue(orchestrator, mock_services):
     mock_services["session"].session_id = "sess1"
     mock_services["backend"].report_issue = AsyncMock()
     mock_services["ui"].show_error = AsyncMock()
+    mock_services["ui"].send_window_message = AsyncMock()
     orchestrator._get_user_info = MagicMock(return_value=None)
 
     await orchestrator.handle_report_issue("reason")
@@ -989,4 +1000,7 @@ async def test_handle_report_issue(orchestrator, mock_services):
         session_id="sess1", reason="reason", user_info=None
     )
     assert mock_services["session"].session_ended is True
+    mock_services["ui"].send_window_message.assert_awaited_once_with(
+        {"type": "aims_session_ended"}
+    )
     mock_services["ui"].show_error.assert_called()

--- a/tests/unit/services/chainlit/test_chainlit_services.py
+++ b/tests/unit/services/chainlit/test_chainlit_services.py
@@ -102,7 +102,7 @@ def test_ui_handler_format_coach_message():
     # Pipe delimited
     input_text = "Step 1 | Feedback here | Tip here"
     formatted = ui.format_coach_message(input_text)
-    assert "**Coaching**" in formatted
+    assert "**Summary**" in formatted
     assert "- Step 1" in formatted
     assert "- Feedback here" in formatted
 
@@ -120,7 +120,7 @@ def test_ui_handler_format_coach_message_filters_phase_and_empty_values():
     )
 
     assert "Conversation phase" not in formatted
-    assert "**Coaching**" in formatted
+    assert "**Summary**" in formatted
     assert "Announce:" in formatted
     assert "Legacy:" not in formatted
     assert "- Tip: Ask an open question" in formatted
@@ -350,7 +350,7 @@ async def test_ui_handler_send_helpers_use_expected_chainlit_calls():
     assert "aims-scenario-briefing" in mock_msg_cls.call_args_list[0].kwargs["content"]
     assert mock_msg_cls.call_args_list[1].args == ("Problem",)
     assert mock_msg_cls.call_args_list[2].args == ("Hello",)
-    assert "**Coaching**" in mock_msg_cls.call_args_list[3].kwargs["content"]
+    assert "**Summary**" in mock_msg_cls.call_args_list[3].kwargs["content"]
     assert "Announce:" in mock_msg_cls.call_args_list[3].kwargs["content"]
     assert "Legacy:" not in mock_msg_cls.call_args_list[3].kwargs["content"]
     assert "**Coaching**" in mock_msg_cls.call_args_list[4].kwargs["content"]


### PR DESCRIPTION
## Summary
- Rename the end-of-session card title from "Coaching" to "Summary" so it's visually distinguishable from ordinary per-turn coaching notes at a glance (per-turn notes still say "Coaching").
- Fix a real bug reported live: after a session ended (via endgame closure or the report-issue flow), the message composer stayed fully enabled and a clinician could keep sending messages. Root cause was two-fold:
  1. `session.session_ended` was only ever set on the report-issue path, never on a normal endgame closure - the existing backend guard in `handle_user_message` never fired for the common case.
  2. Even where it was set, nothing told the browser - the guard only rejected the *next* message after submission with an error toast; the textarea/button stayed interactive.
  
  Both are now fixed: the `coachPost` branch sets `session_ended` too, and both paths send a new `aims_session_ended` window message that the frontend uses to actually disable the composer (re-applied via the existing persistent MutationObserver since Chainlit can re-render the composer after the session ends).

## Test plan
- [x] `pytest --ignore=tests/integration -q` (full CI-equivalent suite, all green)
- [x] `ruff check .`, `mypy app`, `bandit -r app -x tests,scripts`
- [x] Live-tested on staging.aimsbot.ca: an Ethan/flu-vaccine session ending in `accepted_literature` shows the card titled "Summary" (not "Coaching"), and afterward the composer textarea shows the "This session has ended..." placeholder and genuinely rejects further keystrokes - confirmed by attempting to type into it post-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)