### PR TITLE
Lock the composer when resuming an already-ended thread

### DIFF
--- a/app/routes/system.py
+++ b/app/routes/system.py
@@ -16,6 +16,7 @@ from app.constants import (
     ENDPOINT_MODELCHECK,
     ENDPOINT_DIAGNOSTICS,
     ENDPOINT_MODELS,
+    KEY_GAME_OVER,
 )
 
 
@@ -47,10 +48,11 @@ def create_system_router(
         """
         try:
             if not (sessionId and settings.MEMORY_ENABLED):
-                return {"history": []}
+                return {"history": [], "gameOver": False}
             mem = memory_store.get(sessionId) or {}
+            game_over = bool(mem.get(KEY_GAME_OVER))
             if full:
-                return {"history": mem.get("full_history") or []}
+                return {"history": mem.get("full_history") or [], "gameOver": game_over}
             hist = mem.get("history") or []
             out: list[dict[str, Any]] = []
             for it in hist:
@@ -66,10 +68,10 @@ def create_system_router(
                 except Exception as e:
                     logger.debug("Failed to parse history item: %s. Error: %s", it, e)
                     continue
-            return {"history": out}
+            return {"history": out, "gameOver": game_over}
         except Exception as e:
             logger.error("Error retrieving history for session %s: %s", sessionId, e)
-            return {"history": []}
+            return {"history": [], "gameOver": False}
 
     @router.get(ENDPOINT_CONFIG)
     async def config(

--- a/app/services/chainlit/backend_client.py
+++ b/app/services/chainlit/backend_client.py
@@ -34,21 +34,31 @@ class BackendClient:
         
         return url[:-5] if url.endswith(PATH_CHAT) else url
 
-    async def fetch_history(self, session_id: str) -> List[Dict[str, Any]]:
+    async def fetch_history_with_state(self, session_id: str) -> Dict[str, Any]:
+        """Like fetch_history, but also returns gameOver so callers that need to
+        know whether a resumed session already ended don't need a second call."""
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 r = await client.get(
-                    f"{self.base_url}{ENDPOINT_HISTORY}", 
+                    f"{self.base_url}{ENDPOINT_HISTORY}",
                     params={"sessionId": session_id}
                 )
                 if r.status_code == 200 and r.headers.get("content-type", "").startswith("application/json"):
-                    return (r.json() or {}).get("history") or []
+                    data = r.json() or {}
+                    return {
+                        "history": data.get("history") or [],
+                        "gameOver": bool(data.get("gameOver")),
+                    }
                 else:
                     logger.warning("Failed to fetch history: status=%s, content-type=%s", r.status_code, r.headers.get("content-type"))
         except Exception as e:
             logger.error("Failed to fetch history from backend: %s", e)
             pass
-        return []
+        return {"history": [], "gameOver": False}
+
+    async def fetch_history(self, session_id: str) -> List[Dict[str, Any]]:
+        state = await self.fetch_history_with_state(session_id)
+        return state.get("history") or []
 
     async def initialize_session(
         self, 

--- a/app/services/chainlit/orchestrator.py
+++ b/app/services/chainlit/orchestrator.py
@@ -186,8 +186,11 @@ class ChainlitOrchestrator:
                     )
 
                 # Always refresh history from backend source of truth
-                history = await self.backend.fetch_history(session_id)
-                self.session.history = history
+                history_state = await self.backend.fetch_history_with_state(session_id)
+                self.session.history = history_state.get("history") or []
+                if history_state.get("gameOver"):
+                    self.session.session_ended = True
+                    await self.ui.send_window_message({"type": MSG_SESSION_ENDED})
             except Exception as e:
                 logger.warning(
                     "Failed to refresh history during resume for %s: %s", session_id, e

--- a/docs/api.md
+++ b/docs/api.md
@@ -132,7 +132,10 @@ Query parameters:
 - `full`: optional boolean. When true, returns full history if available.
 
 Response shape is intentionally simple and may include current persona/session
-metadata in addition to history entries.
+metadata in addition to history entries. Also includes `gameOver`: `true` when
+the session already reached an end state (a coach post was produced), so
+clients resuming an old session/thread can detect that without replaying
+history.
 
 ## GET /summary
 

--- a/tests/unit/routes/test_routes_system_unit.py
+++ b/tests/unit/routes/test_routes_system_unit.py
@@ -94,9 +94,25 @@ def test_history_filters_malformed_working_history_items():
         "history": [
             {"role": "user", "content": "hello"},
             {"role": "coach", "content": "hint", "coaching": {"step": "Secure"}},
-        ]
+        ],
+        "gameOver": False,
     }
     assert store["sid"]["full_history"][0]["time"] == 1
+
+
+def test_history_surfaces_game_over_so_resume_can_lock_the_composer():
+    client, _ = _client(
+        store={
+            "sid": {
+                "history": [{"role": "user", "content": "hello"}],
+                "game_over": True,
+            }
+        }
+    )
+
+    response = client.get("/history", params={"sessionId": "sid"})
+
+    assert response.json()["gameOver"] is True
 
 
 def test_history_full_and_disabled_memory_paths():
@@ -105,13 +121,17 @@ def test_history_full_and_disabled_memory_paths():
         store={"sid": {"full_history": [{"role": "user", "content": "hello", "time": 1}]}},
     )
 
-    assert client.get("/history", params={"sessionId": "sid", "full": True}).json() == {"history": []}
+    assert client.get("/history", params={"sessionId": "sid", "full": True}).json() == {
+        "history": [],
+        "gameOver": False,
+    }
 
     client, _ = _client(
         store={"sid": {"full_history": [{"role": "user", "content": "hello", "time": 1}]}}
     )
     assert client.get("/history", params={"sessionId": "sid", "full": True}).json() == {
-        "history": [{"role": "user", "content": "hello", "time": 1}]
+        "history": [{"role": "user", "content": "hello", "time": 1}],
+        "gameOver": False,
     }
 
 
@@ -124,7 +144,10 @@ def test_history_returns_empty_when_memory_store_raises():
 
     client, _ = _client(store=RaisingStore(), logger=logger)
 
-    assert client.get("/history", params={"sessionId": "sid"}).json() == {"history": []}
+    assert client.get("/history", params={"sessionId": "sid"}).json() == {
+        "history": [],
+        "gameOver": False,
+    }
     logger.error.assert_called_once()
 
 

--- a/tests/unit/services/chainlit/test_chainlit_orchestrator.py
+++ b/tests/unit/services/chainlit/test_chainlit_orchestrator.py
@@ -284,10 +284,11 @@ async def test_handle_session_resume_refreshes_backend_history(
             "scene": "Recovered scene",
         }
     )
-    mock_services["backend"].fetch_history = AsyncMock(
-        return_value=[
-            {"role": "assistant", "content": "Recovered reply"},
-        ]
+    mock_services["backend"].fetch_history_with_state = AsyncMock(
+        return_value={
+            "history": [{"role": "assistant", "content": "Recovered reply"}],
+            "gameOver": False,
+        }
     )
 
     await orchestrator.handle_session_resume(
@@ -315,6 +316,46 @@ async def test_handle_session_resume_refreshes_backend_history(
         "identifier": "user@example.com",
         "metadata": {"name": "User"},
     }
+
+
+@pytest.mark.asyncio
+async def test_handle_session_resume_locks_composer_when_already_game_over(
+    orchestrator, mock_services, monkeypatch
+):
+    """Resuming a thread whose session already ended (coach_post was produced)
+    must lock the composer immediately - without this, a clinician could keep
+    chatting in a scenario that's already finished."""
+    user = MagicMock(identifier="user@example.com", metadata={"name": "User"})
+    mock_services["session"].get_user_identifier.return_value = user.identifier
+    mock_services["session"].user = user
+    mock_services["session"].connection_id = None
+    mock_services["session"].character = None
+    mock_services["session"].scene = None
+    orchestrator._has_seen_intro_locally_or_persistently = MagicMock(return_value=True)
+    orchestrator._get_thread_id = MagicMock(return_value="thread-from-context")
+    monkeypatch.setattr(
+        "app.services.chainlit.orchestrator.set_current_thread_id",
+        MagicMock(),
+    )
+    mock_services["backend"].initialize_session = AsyncMock(
+        return_value={"character": "Character", "scene": "Scene"}
+    )
+    mock_services["backend"].fetch_history_with_state = AsyncMock(
+        return_value={
+            "history": [{"role": "assistant", "content": "Recovered reply"}],
+            "gameOver": True,
+        }
+    )
+    mock_services["ui"].send_window_message = AsyncMock()
+
+    await orchestrator.handle_session_resume(
+        {"id": "thread-1", "metadata": {"session_id": "session-1"}}
+    )
+
+    assert mock_services["session"].session_ended is True
+    mock_services["ui"].send_window_message.assert_awaited_once_with(
+        {"type": "aims_session_ended"}
+    )
 
 
 @pytest.mark.asyncio
@@ -383,8 +424,11 @@ async def test_handle_session_resume_passes_force_query(orchestrator, mock_servi
             "scene": "Scene",
         }
     )
-    mock_services["backend"].fetch_history = AsyncMock(
-        return_value=[{"role": "system", "content": "Person: Zia"}]
+    mock_services["backend"].fetch_history_with_state = AsyncMock(
+        return_value={
+            "history": [{"role": "system", "content": "Person: Zia"}],
+            "gameOver": False,
+        }
     )
     mock_services["ui"].send_window_message = AsyncMock()
 
@@ -447,7 +491,9 @@ async def test_handle_session_resume_empty_history_starts_fresh_scenario(
             "scene": "Recovered scene",
         }
     )
-    mock_services["backend"].fetch_history = AsyncMock(return_value=[])
+    mock_services["backend"].fetch_history_with_state = AsyncMock(
+        return_value={"history": [], "gameOver": False}
+    )
     orchestrator._start_scenario_flow = AsyncMock()
 
     await orchestrator.handle_session_resume({"id": "thread-1", "metadata": {}})

--- a/tests/unit/services/chainlit/test_chainlit_services.py
+++ b/tests/unit/services/chainlit/test_chainlit_services.py
@@ -97,6 +97,22 @@ async def test_backend_client_fetch_history(respx_mock):
     assert len(history) == 1
     assert history[0]["content"] == "hi"
 
+
+@pytest.mark.asyncio
+async def test_backend_client_fetch_history_with_state_surfaces_game_over(respx_mock):
+    client = BackendClient(base_url="http://test")
+    respx_mock.get("http://test/history?sessionId=123").mock(
+        return_value=httpx.Response(
+            200,
+            json={"history": [{"role": "user", "content": "hi"}], "gameOver": True},
+        )
+    )
+
+    state = await client.fetch_history_with_state("123")
+    assert state["gameOver"] is True
+    assert state["history"][0]["content"] == "hi"
+
+
 def test_ui_handler_format_coach_message():
     ui = UIHandler()
     # Pipe delimited


### PR DESCRIPTION
## Summary
The just-shipped composer-lock fix only covered ending a session within the current browser connection - `session_ended` lives in `cl.user_session`, which resets on every new connection, and the resume flow never checked whether the session it was reloading had already ended. Returning to a finished thread from the Chainlit sidebar (or a plain page reload) left the composer fully interactive again, reopening the same bug through a third entry point - caught by the user asking exactly this question.

`GET /history` now also returns the existing `game_over` memory flag as `gameOver`, and `handle_session_resume` locks the composer immediately when it's set. `BackendClient.fetch_history_with_state()` is the new call `handle_session_resume` uses to get both history and `gameOver` in one round trip; `fetch_history()` is now a thin wrapper over it so existing callers/tests are unaffected.

## Test plan
- [x] `pytest --ignore=tests/integration -q` (full CI-equivalent suite, all green)
- [x] `ruff check .`, `mypy app`, `bandit -r app -x tests,scripts`
- [x] Live-tested on staging.aimsbot.ca: ran a Sarah/Emily scenario to endgame, switched to a new scenario (Zia), then clicked back into the ended Sarah thread from the sidebar - the composer showed the ended-session placeholder immediately and genuinely rejected typed input, confirmed by attempting to type into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)